### PR TITLE
GHDL tweaks for Linux

### DIFF
--- a/OsvvmProjectScripts.tcl
+++ b/OsvvmProjectScripts.tcl
@@ -53,6 +53,7 @@
 #  limitations under the License.
 #
 
+
 namespace eval ::osvvm {
 
 # -------------------------------------------------

--- a/OsvvmProjectScripts.tcl
+++ b/OsvvmProjectScripts.tcl
@@ -603,7 +603,7 @@ proc MapAllLibraries {{Path_Or_File "."}} {
 # Don't export the following due to conflicts with Tcl built-ins
 # map
 
-namespace export analyze build include library
+namespace export analyze simulate build include library
 namespace export StartUp Do_List StartTranscript StopTranscript TerminateTranscript
 namespace export RemoveAllLibraries CreateDirectory OsvvmInitialize
 namespace export SetVHDLVersion GetVHDLVersion SetSimulatorResolution GetSimulatorResolution

--- a/OsvvmScriptDefaults.tcl
+++ b/OsvvmScriptDefaults.tcl
@@ -42,7 +42,8 @@
 # OSVVM requires 2008 or newer
 # Accepted parameters:  1993, 2002, 2008, 2019
 # OSVVM Usage:  test 2019 features
-SetVHDLVersion 2008
+
+SetVHDLVersion [expr {[info exists ::osvvm::DefaultVHDLVersion] ? $::osvvm::DefaultVHDLVersion : 2008 }]
 
 # VHDL Simulation time units - Simulator is started with this value
 SetSimulatorResolution  ps

--- a/StartUp.tcl
+++ b/StartUp.tcl
@@ -53,34 +53,40 @@
 #  limitations under the License.
 #
 
-# Initial SCRIPT_DIR setup - revised by ActiveHDL VSimSA
-set SCRIPT_DIR  [file dirname [file normalize [info script]]]
 
-# 
-# Find the simulator
-#
-set ToolExecutable [info nameofexecutable]
-set ToolExecutableName [file rootname [file tail $ToolExecutable]]
+namespace eval ::osvvm {
+  # Initial SCRIPT_DIR setup - revised by ActiveHDL VSimSA
+  variable SCRIPT_DIR  [file dirname [file normalize [info script]]]
+  
+  # 
+  # Find the simulator
+  #
+  variable ToolExecutable [info nameofexecutable]
+  variable ToolExecutableName [file rootname [file tail $ToolExecutable]]
 
-if {[info exists aldec]} {
-  if {$ToolExecutableName eq "riviera" || $ToolExecutableName eq "vsimsa"} {
-    source ${SCRIPT_DIR}/VendorScripts_RivieraPro.tcl
+  if {[info exists aldec]} {
+    if {$ToolExecutableName eq "riviera" || $ToolExecutableName eq "vsimsa"} {
+      source ${SCRIPT_DIR}/VendorScripts_RivieraPro.tcl
 
-  } elseif {[string match $ToolExecutableName "VSimSA"]} {
-    set SCRIPT_DIR [file dirname [string trim $argv0 ?{}?]]
-    source ${SCRIPT_DIR}/VendorScripts_VSimSA.tcl
+    } elseif {[string match $ToolExecutableName "VSimSA"]} {
+      set SCRIPT_DIR [file dirname [string trim $argv0 ?{}?]]
+      source ${SCRIPT_DIR}/VendorScripts_VSimSA.tcl
 
+    } else {
+      source ${SCRIPT_DIR}/VendorScripts_ActiveHDL.tcl
+    }
+  } elseif {[string match $ToolExecutableName "vish"]} {
+    source ${SCRIPT_DIR}/VendorScripts_Mentor.tcl
+  } elseif {[string match -nocase $ToolExecutableName "vivado"]} {
+    source ${SCRIPT_DIR}/VendorScripts_Vivado.tcl
   } else {
-    source ${SCRIPT_DIR}/VendorScripts_ActiveHDL.tcl
+    source ${SCRIPT_DIR}/VendorScripts_GHDL.tcl
   }
-} elseif {[string match $ToolExecutableName "vish"]} {
-  source ${SCRIPT_DIR}/VendorScripts_Mentor.tcl
-} else {
-  source ${SCRIPT_DIR}/VendorScripts_GHDL.tcl
 }
 
 # OSVVM Project Scripts 
-source ${SCRIPT_DIR}/OsvvmProjectScripts.tcl
+source ${::osvvm::SCRIPT_DIR}/OsvvmProjectScripts.tcl
+namespace import ::osvvm::*
 
 # Set OSVVM Script Defaults - defaults may call scripts
-source ${SCRIPT_DIR}/OsvvmScriptDefaults.tcl
+source ${::osvvm::SCRIPT_DIR}/OsvvmScriptDefaults.tcl

--- a/VendorScripts_ActiveHDL.tcl
+++ b/VendorScripts_ActiveHDL.tcl
@@ -82,7 +82,6 @@ proc vendor_library {LibraryName PathToLib} {
     endsim
   }  
   set MY_START_DIR [pwd]
-
   set PathAndLib ${PathToLib}/${LibraryName}
 
   if {![file exists ${PathAndLib}]} {
@@ -166,14 +165,14 @@ proc vendor_end_previous_simulation {} {
 #
 proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
   variable SCRIPT_DIR
+  variable SIMULATE_TIME_UNITS
   variable ToolVendor
   variable simulator
 
   set MY_START_DIR [pwd]
   
-#  puts "Simulate Start time [clock format $::SimulateStartTime -format %T]"
-  puts {vsim -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands}} 
-  eval vsim -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} 
+  puts {vsim -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands}} 
+  eval vsim -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} 
   
   # ActiveHDL changes the directory, so change it back to the OSVVM run directory
   cd $MY_START_DIR

--- a/VendorScripts_ActiveHDL.tcl
+++ b/VendorScripts_ActiveHDL.tcl
@@ -50,12 +50,12 @@
 # -------------------------------------------------
 # Tool Settings
 #
-  set ToolType    "simulator"
-  set ToolVendor  "Aldec"
-  set simulator   "ActiveHDL"
-  set ToolNameVersion ${simulator}-${version}
+  variable ToolType    "simulator"
+  variable ToolVendor  "Aldec"
+  variable simulator   "ActiveHDL"
+  variable ToolNameVersion ${simulator}-${version}
   puts $ToolNameVersion
-  # Allow global OSVVM library to be updated
+  # Allow variable OSVVM library to be updated
   setlibrarymode -rw osvvm
 
 
@@ -77,7 +77,7 @@ proc vendor_StopTranscript {FileName} {
 # Library
 #
 proc vendor_library {LibraryName PathToLib} {
-  global vendor_simulate_started
+  variable vendor_simulate_started
   if {[info exists vendor_simulate_started]} {
     endsim
   }  
@@ -101,7 +101,7 @@ proc vendor_library {LibraryName PathToLib} {
 
 
 proc vendor_map {LibraryName ResolvedPathToLib} {
-  global vendor_simulate_started
+  variable vendor_simulate_started
   if {[info exists vendor_simulate_started]} {
     endsim
   }  
@@ -124,8 +124,8 @@ proc vendor_map {LibraryName ResolvedPathToLib} {
 # analyze
 #
 proc vendor_analyze_vhdl {LibraryName FileName} {
-  global OsvvmVhdlVersion
-  global DIR_LIB
+  variable VhdlVersion
+  variable DIR_LIB
   
   set MY_START_DIR [pwd]
   set FileBaseName [file rootname [file tail $FileName]]
@@ -134,12 +134,12 @@ proc vendor_analyze_vhdl {LibraryName FileName} {
   if {![file isfile ${DIR_LIB}/$LibraryName/src/${FileBaseName}.vcom]} {
     echo addfile ${FileName}
     addfile ${FileName}
-    filevhdloptions -${OsvvmVhdlVersion} ${FileName}
+    filevhdloptions -${VhdlVersion} ${FileName}
   }
   # Compile it.
-  echo vcom -${OsvvmVhdlVersion} -dbg -relax -work ${LibraryName} ${FileName} 
-  echo vcom -${OsvvmVhdlVersion} -dbg -relax -work ${LibraryName} ${FileName} > ${DIR_LIB}/$LibraryName/src/${FileBaseName}.vcom
-  eval vcom -${OsvvmVhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
+  echo vcom -${VhdlVersion} -dbg -relax -work ${LibraryName} ${FileName} 
+  echo vcom -${VhdlVersion} -dbg -relax -work ${LibraryName} ${FileName} > ${DIR_LIB}/$LibraryName/src/${FileBaseName}.vcom
+  eval vcom -${VhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
   
   cd $MY_START_DIR
 }
@@ -165,9 +165,9 @@ proc vendor_end_previous_simulation {} {
 # Simulate
 #
 proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
-  global SCRIPT_DIR
-  global ToolVendor
-  global simulator
+  variable SCRIPT_DIR
+  variable ToolVendor
+  variable simulator
 
   set MY_START_DIR [pwd]
   

--- a/VendorScripts_GHDL.tcl
+++ b/VendorScripts_GHDL.tcl
@@ -56,7 +56,7 @@
     variable console {}
   }
   
-  regexp {GHDL\s+\d+\.\d+\.\S+} [exec $ghdl --version] VersionString
+  regexp {GHDL\s+\d+\.\d+\S*} [exec $ghdl --version] VersionString
   variable ToolNameVersion [regsub {\s+} $VersionString -]
   puts $ToolNameVersion
 

--- a/VendorScripts_GHDL.tcl
+++ b/VendorScripts_GHDL.tcl
@@ -44,13 +44,13 @@
 # -------------------------------------------------
 # Tool Settings
 #
-  set ToolType   "simulator"
-  set ToolVendor "GHDL"
-  set simulator  "GHDL"
-  set ghdl "ghdl"
+  variable ToolType   "simulator"
+  variable ToolVendor "GHDL"
+  variable simulator  "GHDL"
+  variable ghdl "ghdl"
   # required for mintty
-  set console "/dev/pty0"
-  set ToolNameVersion "GHDL-v0.37.0-1063-gc5b094bb-2020-1023"
+  variable console "/dev/pty0"
+  variable ToolNameVersion "GHDL-v0.37.0-1063-gc5b094bb-2020-1023"
   puts $ToolNameVersion
 
 
@@ -58,7 +58,7 @@
 # StartTranscript / StopTranscxript
 #
 proc vendor_StartTranscript {FileName} {
-  global GHDL_TRANSCRIPT_FILE
+  variable GHDL_TRANSCRIPT_FILE
    
   if {[info exists GHDL_TRANSCRIPT_FILE]} {
     unset GHDL_TRANSCRIPT_FILE 
@@ -69,7 +69,7 @@ proc vendor_StartTranscript {FileName} {
 }
 
 proc vendor_StopTranscript {FileName} {
-  global GHDL_TRANSCRIPT_FILE
+  variable GHDL_TRANSCRIPT_FILE
    
 #  unset GHDL_TRANSCRIPT_FILE 
   puts "Stop Transcript $GHDL_TRANSCRIPT_FILE" 
@@ -81,9 +81,9 @@ proc vendor_StopTranscript {FileName} {
 # Library
 #
 proc vendor_library {LibraryName PathToLib} {
-  global VHDL_WORKING_LIBRARY_PATH
-#  global VHDL_RESOURCE_LIBRARY_PATHS
-  global GHDL_TRANSCRIPT_FILE
+  variable VHDL_WORKING_LIBRARY_PATH
+#  variable VHDL_RESOURCE_LIBRARY_PATHS
+  variable GHDL_TRANSCRIPT_FILE
    
 #  set PathAndLib ${PathToLib}/${LibraryName}.lib
   set PathAndLib ${PathToLib}/${LibraryName}/v08
@@ -107,8 +107,8 @@ proc vendor_library {LibraryName PathToLib} {
 }
 
 proc vendor_map {LibraryName PathToLib} {
-  global VHDL_WORKING_LIBRARY_PATH
-  global GHDL_TRANSCRIPT_FILE
+  variable VHDL_WORKING_LIBRARY_PATH
+  variable GHDL_TRANSCRIPT_FILE
 
   set PathAndLib ${PathToLib}/${LibraryName}.lib
 
@@ -124,22 +124,22 @@ proc vendor_map {LibraryName PathToLib} {
 # analyze
 #
 proc vendor_analyze_vhdl {LibraryName FileName} {
-  global OsvvmVhdlShortVersion
-  global ghdl 
-  global console
-  global VHDL_WORKING_LIBRARY_PATH
-#  global VHDL_RESOURCE_LIBRARY_PATHS
-  global GHDL_TRANSCRIPT_FILE
-  global DIR_LIB
+  variable VhdlShortVersion
+  variable ghdl 
+  variable console
+  variable VHDL_WORKING_LIBRARY_PATH
+#  variable VHDL_RESOURCE_LIBRARY_PATHS
+  variable GHDL_TRANSCRIPT_FILE
+  variable DIR_LIB
 
 #  puts "$ghdl -a --std=08 -Wno-hide --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} ${VHDL_RESOURCE_LIBRARY_PATHS} ${FileName}" 
 #  eval exec $ghdl -a --std=08 -Wno-hide --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} ${VHDL_RESOURCE_LIBRARY_PATHS} ${FileName} | tee -a $GHDL_TRANSCRIPT_FILE $console
-  exec echo "$ghdl -a --std=${OsvvmVhdlShortVersion} -Wno-hide --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} -P${DIR_LIB} ${FileName}" | tee -a $GHDL_TRANSCRIPT_FILE $console
-  eval exec $ghdl -a --std=${OsvvmVhdlShortVersion} -Wno-hide --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} -P${DIR_LIB} ${FileName} |& tee -a $GHDL_TRANSCRIPT_FILE $console
+  exec echo "$ghdl -a --std=${VhdlShortVersion} -Wno-hide --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} -P${DIR_LIB} ${FileName}" | tee -a $GHDL_TRANSCRIPT_FILE $console
+  eval exec $ghdl -a --std=${VhdlShortVersion} -Wno-hide --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} -P${DIR_LIB} ${FileName} |& tee -a $GHDL_TRANSCRIPT_FILE $console
 }
 
 proc vendor_analyze_verilog {LibraryName FileName} {
-  global GHDL_TRANSCRIPT_FILE
+  variable GHDL_TRANSCRIPT_FILE
 
   puts "Analyzing verilog files not supported by GHDL" 
 }
@@ -147,7 +147,7 @@ proc vendor_analyze_verilog {LibraryName FileName} {
 # -------------------------------------------------
 # End Previous Simulation
 #
-proc vendor_end_previous_simulation  {
+proc vendor_end_previous_simulation {} {
   # Do Nothing
 }  
 
@@ -155,16 +155,16 @@ proc vendor_end_previous_simulation  {
 # Simulate
 #
 proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
-  global OsvvmVhdlShortVersion
-  global ghdl 
-  global console
-  global VHDL_WORKING_LIBRARY_PATH
-#  global VHDL_RESOURCE_LIBRARY_PATHS
-  global GHDL_TRANSCRIPT_FILE
-  global DIR_LIB
+  variable VhdlShortVersion
+  variable ghdl 
+  variable console
+  variable VHDL_WORKING_LIBRARY_PATH
+#  variable VHDL_RESOURCE_LIBRARY_PATHS
+  variable GHDL_TRANSCRIPT_FILE
+  variable DIR_LIB
 
 #  puts "$ghdl --elab-run --std=08 --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} ${VHDL_RESOURCE_LIBRARY_PATHS} ${LibraryUnit}" 
 #  eval exec $ghdl --elab-run --std=08 --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} ${VHDL_RESOURCE_LIBRARY_PATHS} ${LibraryUnit} | tee -a $GHDL_TRANSCRIPT_FILE $console
-  exec echo "$ghdl --elab-run --std=${OsvvmVhdlShortVersion} --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} -P${DIR_LIB} ${LibraryUnit}" | tee -a $GHDL_TRANSCRIPT_FILE $console
-  eval exec $ghdl --elab-run --std=${OsvvmVhdlShortVersion} --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} -P${DIR_LIB} ${LibraryUnit} |& tee -a $GHDL_TRANSCRIPT_FILE $console
+  exec echo "$ghdl --elab-run --std=${VhdlShortVersion} --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} -P${DIR_LIB} ${LibraryUnit}" | tee -a $GHDL_TRANSCRIPT_FILE $console
+  eval exec $ghdl --elab-run --std=${VhdlShortVersion} --work=${LibraryName} --workdir=${VHDL_WORKING_LIBRARY_PATH} -P${DIR_LIB} ${LibraryUnit} |& tee -a $GHDL_TRANSCRIPT_FILE $console
 }

--- a/VendorScripts_Mentor.tcl
+++ b/VendorScripts_Mentor.tcl
@@ -139,7 +139,6 @@ proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
   variable ToolVendor
   variable simulator
 
-#  puts "Simulate Start time [clock format $::SimulateStartTime -format %T]"
   puts {vsim -voptargs="+acc" -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} -suppress 8683 -suppress 8684 -suppress 8617}
   eval vsim -voptargs="+acc" -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} -suppress 8683 -suppress 8684 -suppress 8617
   

--- a/VendorScripts_Mentor.tcl
+++ b/VendorScripts_Mentor.tcl
@@ -46,18 +46,17 @@
 #  limitations under the License.
 #
 
-
 # -------------------------------------------------
 # Tool Settings
 #
-  quietly set ToolType    "simulator"
-  quietly set ToolVendor  "Siemens"
+  variable ToolType    "simulator"
+  variable ToolVendor  "Siemens"
   if {[lindex [split [vsim -version]] 0] eq "Questa"} {
-    quietly set simulator   "QuestaSim"
+    variable simulator   "QuestaSim"
   } else {
-    quietly set simulator   "ModelSim"
+    variable simulator   "ModelSim"
   }
-  quietly set ToolNameVersion ${simulator}-[vsimVersion]
+  variable ToolNameVersion ${simulator}-[vsimVersion]
   puts $ToolNameVersion
 
 
@@ -106,9 +105,9 @@ proc vendor_map {LibraryName PathToLib} {
 # analyze
 #
 proc vendor_analyze_vhdl {LibraryName FileName} {
-  global OsvvmVhdlVersion
-  echo vcom -${OsvvmVhdlVersion} -work ${LibraryName} ${FileName}
-  eval vcom -${OsvvmVhdlVersion} -work ${LibraryName} ${FileName}
+  variable VhdlVersion
+  echo vcom -${VhdlVersion} -work ${LibraryName} ${FileName}
+  eval vcom -${VhdlVersion} -work ${LibraryName} ${FileName}
 }
 
 proc vendor_analyze_verilog {LibraryName FileName} {
@@ -121,7 +120,7 @@ proc vendor_analyze_verilog {LibraryName FileName} {
 # End Previous Simulation
 #
 proc vendor_end_previous_simulation {} {
-  global SourceMap
+  variable SourceMap
 
   # close junk in source window
   foreach index [array names SourceMap] { 
@@ -135,13 +134,14 @@ proc vendor_end_previous_simulation {} {
 # Simulate
 #
 proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
-  global SCRIPT_DIR
-  global ToolVendor
-  global simulator
+  variable SCRIPT_DIR
+  variable SIMULATE_TIME_UNITS
+  variable ToolVendor
+  variable simulator
 
 #  puts "Simulate Start time [clock format $::SimulateStartTime -format %T]"
-  puts {vsim -voptargs="+acc" -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} -suppress 8683 -suppress 8684 -suppress 8617}
-  eval vsim -voptargs="+acc" -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} -suppress 8683 -suppress 8684 -suppress 8617
+  puts {vsim -voptargs="+acc" -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} -suppress 8683 -suppress 8684 -suppress 8617}
+  eval vsim -voptargs="+acc" -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} -suppress 8683 -suppress 8684 -suppress 8617
   
   ### Project level settings - in OsvvmLibraries/Scripts
   # Historical name.  Must be run with "do" for actions to work

--- a/VendorScripts_RivieraPro.tcl
+++ b/VendorScripts_RivieraPro.tcl
@@ -50,11 +50,11 @@
 # -------------------------------------------------
 # Tool Settings
 #
-  set ToolType    "simulator"
-  set ToolVendor  "Aldec"
-  set simulator   "RivieraPRO"
+  variable ToolType    "simulator"
+  variable ToolVendor  "Aldec"
+  variable simulator   "RivieraPRO"
   #  Could differentiate between RivieraPRO and VSimSA
-  set ToolNameVersion ${simulator}-[asimVersion]
+  variable ToolNameVersion ${simulator}-[asimVersion]
   puts $ToolNameVersion
 
 
@@ -106,9 +106,9 @@ proc vendor_map {LibraryName PathToLib} {
 # analyze
 #
 proc vendor_analyze_vhdl {LibraryName FileName} {
-  global OsvvmVhdlVersion
-  echo vcom -${OsvvmVhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
-  eval vcom -${OsvvmVhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
+  variable VhdlVersion
+  echo vcom -${VhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
+  eval vcom -${VhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
 }
 
 proc vendor_analyze_verilog {LibraryName FileName} {
@@ -129,9 +129,9 @@ proc vendor_end_previous_simulation {} {
 # Simulate
 #
 proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
-  global SCRIPT_DIR
-  global ToolVendor
-  global simulator
+  variable SCRIPT_DIR
+  variable ToolVendor
+  variable simulator
 
 #  puts "Simulate Start time [clock format $::SimulateStartTime -format %T]"
   puts {vsim -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands}} 

--- a/VendorScripts_RivieraPro.tcl
+++ b/VendorScripts_RivieraPro.tcl
@@ -130,12 +130,12 @@ proc vendor_end_previous_simulation {} {
 #
 proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
   variable SCRIPT_DIR
+  variable SIMULATE_TIME_UNITS
   variable ToolVendor
   variable simulator
 
-#  puts "Simulate Start time [clock format $::SimulateStartTime -format %T]"
-  puts {vsim -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands}} 
-  eval vsim -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} 
+  puts {vsim -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands}} 
+  eval vsim -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} 
   
   ### Project level settings - in OsvvmLibraries/Scripts
   # Project Vendor script

--- a/VendorScripts_VSimSA.tcl
+++ b/VendorScripts_VSimSA.tcl
@@ -124,12 +124,12 @@ proc vendor_end_previous_simulation {} {
 #
 proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
   variable SCRIPT_DIR
+  variable SIMULATE_TIME_UNITS
   variable ToolVendor
   variable simulator
 
-#  puts "Simulate Start time [clock format $::SimulateStartTime -format %T]"
-  puts {vsim -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands}}
-  eval vsim -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} 
+  puts {vsim -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands}}
+  eval vsim -t $SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands} 
   
   ### Project level settings - in OsvvmLibraries/Scripts
   # Project Vendor script

--- a/VendorScripts_VSimSA.tcl
+++ b/VendorScripts_VSimSA.tcl
@@ -49,10 +49,10 @@
 # -------------------------------------------------
 # Tool Settings
 #
-  set ToolType    "simulator"
-  set ToolVendor  "Aldec"
-  set simulator   "VSimSA"
-  set ToolNameVersion ${simulator}-[lindex [split $version] [llength $version]-1]
+  variable ToolType    "simulator"
+  variable ToolVendor  "Aldec"
+  variable simulator   "VSimSA"
+  variable ToolNameVersion ${simulator}-[lindex [split $version] [llength $version]-1]
   puts $ToolNameVersion
 
 
@@ -101,9 +101,9 @@ proc vendor_map {LibraryName PathToLib} {
 # analyze
 #
 proc vendor_analyze_vhdl {LibraryName FileName} {
-  global OsvvmVhdlVersion
-  echo vcom -${OsvvmVhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
-  eval vcom -${OsvvmVhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
+  variable VhdlVersion
+  echo vcom -${VhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
+  eval vcom -${VhdlVersion} -dbg -relax -work ${LibraryName} ${FileName}
 }
 
 proc vendor_analyze_verilog {LibraryName FileName} {
@@ -123,9 +123,9 @@ proc vendor_end_previous_simulation {} {
 # Simulate
 #
 proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {
-  global SCRIPT_DIR
-  global ToolVendor
-  global simulator
+  variable SCRIPT_DIR
+  variable ToolVendor
+  variable simulator
 
 #  puts "Simulate Start time [clock format $::SimulateStartTime -format %T]"
   puts {vsim -t $::SIMULATE_TIME_UNITS -lib ${LibraryName} ${LibraryUnit} ${OptionalCommands}}

--- a/VendorScripts_Vivado.tcl
+++ b/VendorScripts_Vivado.tcl
@@ -1,0 +1,128 @@
+#  File Name:         VendorScripts_Vivado.tcl
+#  Purpose:           Scripts for running simulations
+#  Revision:          OSVVM MODELS STANDARD VERSION
+# 
+#  Maintainer:        Jim Lewis      email:  jim@synthworks.com 
+#  Contributor(s):            
+#     Jim Lewis      email:  jim@synthworks.com   
+#     Rob Gaddi      email:  rgaddi@highlandtechnology.com
+# 
+#  Description
+#    Tcl procedures for Xilinx Vivado with the intent of making running 
+#    compiling and simulations tool independent
+#    
+#  Revision History:
+#    Date      Version    Description
+#     4/2021   2021.02    Initial revision, tested under Vivado 2020.1
+#
+#
+#  This file is part of OSVVM.
+#  
+#  Copyright (c) 2021 by SynthWorks Design Inc.  
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# -------------------------------------------------
+# Tool Settings
+#
+  variable ToolType    "synthesis"
+  variable ToolVendor  "Xilinx"
+  variable simulator   "Vivado"
+  variable ToolNameVersion "Vivado-[version -short]"
+  puts $ToolNameVersion
+  
+  # Quite unfortunately, much of Vivado doesn't support VHDL-2008 properly.
+  # Therefore the default assumption has to be for VHDL-2002
+  variable DefaultVHDLVersion 2002
+  
+  # Try to get the default library name from the open project, but we can
+  # fall back to a hard-coded default if necessary.
+  #if {[catch set XILINX_LIB [get_property DEFAULT_LIB [current_project]]} {
+  #  set XILINX_LIB xil_defaultlib
+  #}
+
+# -------------------------------------------------
+# StartTranscript / StopTranscxript
+#
+
+# Haven't been able to find any way to get Vivado to support transcript control
+# However, it is a convenient hook to use to suppress some warning messages
+# that are otherwise tacky.
+
+proc vendor_StartTranscript {FileName} {
+  # WARNING: [filemgmt 56-12] File ... cannot be added to the project because
+  # it already exists in the project, skipping this file 
+  set_msg_config -id {filemgmt 56-12} -suppress -quiet
+}
+
+proc vendor_StopTranscript {FileName} {
+  reset_msg_config -id {filemgmt 56-12} -default_severity -quiet
+}
+
+
+# -------------------------------------------------
+# Library
+#
+
+# Vivado doesn't maintain library files per se, so there's nothing to do.
+
+proc vendor_library {LibraryName PathToLib} {}
+proc vendor_map {LibraryName PathToLib} {}
+
+# -------------------------------------------------
+# analyze
+#
+
+proc vendor_analyze_vhdl {LibraryName FileName} {
+  variable VhdlVersion
+  if {$VhdlVersion eq "2008"} {
+    set f [read_vhdl -library $LibraryName -vhdl2008 $FileName]
+  } else {
+    set f [read_vhdl -library $LibraryName $FileName]
+  }
+  
+  if {$f eq {}} {
+    # The file was already present in the project, so update the parameters
+    set f [get_files $FileName]
+    set_property LIBRARY $LibraryName $f
+    if {$VhdlVersion eq "2008"} {
+      set_property FILE_TYPE {VHDL 2008} $f
+    } else {
+      set_property FILE_TYPE {VHDL} $f
+    }
+  }
+}
+
+proc vendor_analyze_verilog {LibraryName FileName} {
+  set f [read_verilog -library $LibraryName $FileName]
+  if {$f eq {}} {
+    # The file was already present in the project, so update the parameters
+    set f [get_files $FileName]
+    set_property LIBRARY $LibraryName $f
+  }
+}
+
+
+# -------------------------------------------------
+# End Previous Simulation
+#
+
+# -------------------------------------------------
+# Simulate
+
+# Since Vivado simulator doesn't support OSVVM, don't even attempt to do
+# any simulation stuff; just stub it.
+
+proc vendor_end_previous_simulation {} {}
+proc vendor_simulate {LibraryName LibraryUnit OptionalCommands} {}


### PR DESCRIPTION
Updated GHDL vendor script to fix some Linux problems.  Library directories are now forced to be lowercase (GHDL wasn't finding mixed-case directories on a case-sensitive filesystem), and the tee statements do not try to write to /dev/pty0 if that is not a writable device.

Also changed the ToolNameVersion to reflect the actual GHDL version; it had been hardcoded in the script.

As a note, I was **not** able to build RunAllTests.pro, either before or after these changes.  This does at least allow me to successfully build OsvvmLibraries.pro, but even on the latest GHDL from the upstream master (2.0.0) I'm getting a SYSTEM.ASSERTIONS.ASSERT_FAILURE : vhdl-nodes.adb:861 from GHDL.
