### PR TITLE
GHDL tweaks for Linux

### DIFF
--- a/VendorScripts_GHDL.tcl
+++ b/VendorScripts_GHDL.tcl
@@ -56,7 +56,7 @@
     variable console {}
   }
   
-  regexp {GHDL\s+\d+\.\d+\.\S+} [exec $ghdl --version] VersionString
+  regexp {GHDL\s+\d+\.\d+\S*} [exec $ghdl --version] VersionString
   variable ToolNameVersion [regsub {\s+} $VersionString -]
   puts $ToolNameVersion
 


### PR DESCRIPTION
Updated GHDL vendor script to fix some Linux problems. Library directories are now forced to be lowercase (GHDL wasn't finding mixed-case directories on a case-sensitive filesystem), and the tee statements do not try to write to /dev/pty0 if that is not a writable device.

Also changed the ToolNameVersion to reflect the actual GHDL version; it had been hardcoded in the script.

As a note, I was not able to build RunAllTests.pro, either before or after these changes. This does at least allow me to successfully build OsvvmLibraries.pro, but even on the latest GHDL from the upstream master (2.0.0) I'm getting a SYSTEM.ASSERTIONS.ASSERT_FAILURE : vhdl-nodes.adb:861 from GHDL.