### PR TITLE
noview doesn't work in batch or command line mode (vsim -c, vsim -batch)

### DIFF
--- a/VendorScripts_Mentor.tcl
+++ b/VendorScripts_Mentor.tcl
@@ -140,8 +140,10 @@ proc vendor_end_previous_simulation {} {
   global SourceMap
 
   # close junk in source window
-  foreach index [array names SourceMap] { 
-    noview source [file tail $index] 
+  if {![catch {noview} msg]} {
+    foreach index [array names SourceMap] { 
+      noview source [file tail $index] 
+    }
   }
   
   quit -sim


### PR DESCRIPTION
we are using vsim in command line / interactive mode. So for automated simulation runs, a call to noview failes because there is no GUI environment. I think putting it inside a catch block is an easy enough workaround