### PR TITLE
Handling of wave.do

### DIFF
--- a/OsvvmProjectScripts.tcl
+++ b/OsvvmProjectScripts.tcl
@@ -1012,10 +1012,13 @@ proc SimulateRunDesignScripts {TestName Directory} {
 proc SimulateRunSubScripts {LibraryUnit Directory} {
   variable ToolVendor
   variable ToolName
+  variable NoGui
   
   RunIfFileExists [file join ${Directory} ${ToolVendor}.tcl]
   RunIfFileExists [file join ${Directory} ${ToolName}.tcl]
-  RunIfFileExists [file join ${Directory} wave.do]
+  if {! $NoGui} {
+    RunIfFileExists [file join ${Directory} wave.do]
+  }
   SimulateRunDesignScripts ${LibraryUnit} ${Directory}
 }
 

--- a/OsvvmProjectScripts.tcl
+++ b/OsvvmProjectScripts.tcl
@@ -1017,7 +1017,9 @@ proc SimulateRunSubScripts {LibraryUnit Directory} {
   RunIfFileExists [file join ${Directory} ${ToolVendor}.tcl]
   RunIfFileExists [file join ${Directory} ${ToolName}.tcl]
   if {! $NoGui} {
-    RunIfFileExists [file join ${Directory} wave.do]
+    if {[catch {RunIfFileExists [file join ${Directory} wave.do]} errorMsg]} {
+      puts "Error loading wave.do: $errorMsg"
+    }
   }
   SimulateRunDesignScripts ${LibraryUnit} ${Directory}
 }

--- a/OsvvmProjectScripts.tcl
+++ b/OsvvmProjectScripts.tcl
@@ -144,7 +144,7 @@ proc include {Path_Or_File} {
   set StartingPath ${CurrentWorkingDirectory}
 
   set JoinName [file join ${StartingPath} ${Path_Or_File}]
-  set NormName [ReducePath $JoinName]
+  set NormName [file normalize $JoinName]
   set RootDir  [file dirname $NormName]
   # Normalize to handle ".." and "."
   set NameToHandle [file tail [file normalize $NormName]]
@@ -491,35 +491,6 @@ proc CheckSimulationDirs {} {
   if {$::osvvm::CoverageEnable && $::osvvm::CoverageSimulateEnable} {
     CreateDirectory [file join $CurrentSimulationDirectory $::osvvm::CoverageDirectory $::osvvm::TestSuiteName]
   }
-}
-
-# -------------------------------------------------
-# ReducePath
-#   Remove "." and ".." from path
-#
-proc ReducePath {PathIn} {
-
-  set CharCount 0
-  set NewPath {}
-  foreach item [file split $PathIn] {
-    if {$item ne ".."}  {
-      if {$item ne "."}  {
-        lappend NewPath $item
-        incr CharCount 1
-      }
-    } else {
-      if {$CharCount >= 1} {
-        set NewPath [lreplace $NewPath end end]
-        incr CharCount -1
-      } else {
-        lappend NewPath $item
-      }
-    }
-  }
-  if {$NewPath eq ""} {
-    set NewPath "."
-  }
-  return [eval file join $NewPath]
 }
 
 # -------------------------------------------------
@@ -887,7 +858,7 @@ proc LocalAnalyze {FileName args} {
   puts "analyze $FileName"                        ; # EchoOsvvmCmd
 
 #  set NormFileName  [file normalize ${CurrentWorkingDirectory}/${FileName}]
-  set NormFileName  [ReducePath [file join ${CurrentWorkingDirectory} ${FileName}]]
+  set NormFileName  [file normalize [file join ${CurrentWorkingDirectory} ${FileName}]]
   set FileExtension [file extension $FileName]
 
   if {$FileExtension eq ".vhd" || $FileExtension eq ".vhdl"} {


### PR DESCRIPTION
- Don't execute wave.do if not in GUI mode (https://github.com/OSVVM/OSVVM-Scripts/issues/29)
- Don't fail the simulation if wave.do throws errors (they are minor, usually because some signals for the waveform viewer could not be found (https://github.com/OSVVM/OSVVM-Scripts/issues/33)
- On my setup, wave.do is sourced twice. I found the reason to be that path comparisons mismatch because the current directory is represented as '.' rather than the absolute path (https://github.com/OSVVM/OSVVM-Scripts/issues/34)

This Pull Request combines three findings regarding wave.do and is a suggestion for resolving the issue(s). However, I am not fully aware of some of the implications (esp. removing the ReducePath procedure).
