### PR TITLE
Add VHDL Short Version to compilation library.

### DIFF
--- a/VendorScripts_NVC.tcl
+++ b/VendorScripts_NVC.tcl
@@ -102,17 +102,17 @@ proc vendor_library {LibraryName PathToLib} {
   variable VHDL_RESOURCE_LIBRARY_PATHS
   variable NVC_WORKING_LIBRARY_PATH
   variable VhdlShortVersion
-   
+
   set PathAndLib [NvcLibraryPath $LibraryName $PathToLib]
 
-  set  GlobalOptions [concat --std=${VhdlShortVersion} --work=${LibraryName}:${PathAndLib}]
+  set  GlobalOptions [concat --std=${VhdlShortVersion} --work=${LibraryName}:${PathAndLib}.${VhdlShortVersion}]
   puts "nvc ${GlobalOptions} --init"
   if {[catch {exec nvc {*}${GlobalOptions} --init} InitErrorMessage]} {
     puts $InitErrorMessage
     error "Failed: library init $LibraryName ($PathAndLib)"
   }
 
-  
+
   if {![info exists VHDL_RESOURCE_LIBRARY_PATHS]} {
     # Create Initial empty list
     set VHDL_RESOURCE_LIBRARY_PATHS ""
@@ -161,7 +161,7 @@ proc vendor_analyze_vhdl {LibraryName FileName args} {
   variable VhdlLibraryFullPath
   variable NVC_WORKING_LIBRARY_PATH
 
-  set  GlobalOptions [concat --std=${VhdlShortVersion} -H 128m --work=${LibraryName}:${NVC_WORKING_LIBRARY_PATH} {*}${VHDL_RESOURCE_LIBRARY_PATHS}]
+  set  GlobalOptions [concat --std=${VhdlShortVersion} -H 128m --work=${LibraryName}:${NVC_WORKING_LIBRARY_PATH}.${VhdlShortVersion} {*}${VHDL_RESOURCE_LIBRARY_PATHS}]
   set  AnalyzeOptions [concat {*}${args} ${FileName}]
   puts "nvc ${GlobalOptions} -a $AnalyzeOptions"
   if {[catch {exec nvc {*}${GlobalOptions} -a {*}$AnalyzeOptions} AnalyzeErrorMessage]} {
@@ -192,7 +192,7 @@ proc vendor_simulate {LibraryName LibraryUnit args} {
   variable ExtendedElaborateOptions
   variable ExtendedRunOptions
 
-  set LocalGlobalOptions [concat --std=${VhdlShortVersion} -H 128m --work=${LibraryName}:${NVC_WORKING_LIBRARY_PATH} {*}${VHDL_RESOURCE_LIBRARY_PATHS}]
+  set LocalGlobalOptions [concat --std=${VhdlShortVersion} -H 128m --work=${LibraryName}:${NVC_WORKING_LIBRARY_PATH}.${VhdlShortVersion} {*}${VHDL_RESOURCE_LIBRARY_PATHS}]
   set LocalElaborateOptions [concat {*}${ExtendedElaborateOptions} {*}${args}  {*}${::osvvm::GenericOptions}]
 
   set LocalReportDirectory [file join ${::osvvm::CurrentSimulationDirectory} ${::osvvm::ReportsDirectory} ${::osvvm::TestSuiteName}]


### PR DESCRIPTION
`nvc` has a feature to allow for libraries compiled with a suffix of the VHDL standard to live side-by-side in harmony without the user mapping to different directories so it's transparent.

This change adds the VHDL short version suffix to the path for the libraries being compiled such that 2008 and 2019 versions of the libraries can be compiled and used with `nvc.`