### PR TITLE
Apply VCS SynopsysGenericOptions at elaboration

### DIFF
--- a/VendorScripts_VCS.tcl
+++ b/VendorScripts_VCS.tcl
@@ -233,7 +233,14 @@ proc vendor_simulate {LibraryName LibraryUnit args} {
     set DebugOptions "-debug_access+all"
   }
 
-  set ElaborateOptions [concat -full64 -time $SimulateTimeUnits ${DebugOptions} {*}${ExtendedElaborateOptions} ${LibraryName}.${LibraryUnit}]
+  if {$::osvvm::GenericDict ne ""} {
+    set SynopsysGenericOptions "-lca -g synopsys_generics.txt"
+    CreateGenericFile ${::osvvm::GenericDict}
+  } else {
+    set SynopsysGenericOptions ""
+  }
+
+  set ElaborateOptions [concat -full64 -time $SimulateTimeUnits ${DebugOptions} {*}${ExtendedElaborateOptions} ${LibraryName}.${LibraryUnit} {*}${SynopsysGenericOptions}]
   puts "vcs ${ElaborateOptions}" 
   set VcsErrorCode [catch {exec vcs {*}${ElaborateOptions}} SimulateErrorMessage]
 #  puts "VcsErrorCode $VcsErrorCode" ;# returns 1 on success
@@ -245,13 +252,6 @@ proc vendor_simulate {LibraryName LibraryUnit args} {
 #  } else {
 #    puts $SimulateErrorMessage
 #  }
-
-  if {$::osvvm::GenericDict ne ""} {
-    set SynopsysGenericOptions "-lca -g synopsys_generics.txt"
-    CreateGenericFile ${::osvvm::GenericDict}
-  } else {
-    set SynopsysGenericOptions ""
-  }
   
   set SimulateOptions [concat {*}${ExtendedRunOptions} {*}${SynopsysGenericOptions} -ucli -do temp_Synopsys_run.tcl]
   puts "./simv ${SimulateOptions}" 

--- a/VendorScripts_VCS.tcl
+++ b/VendorScripts_VCS.tcl
@@ -253,7 +253,7 @@ proc vendor_simulate {LibraryName LibraryUnit args} {
 #    puts $SimulateErrorMessage
 #  }
   
-  set SimulateOptions [concat {*}${ExtendedRunOptions} {*}${SynopsysGenericOptions} -ucli -do temp_Synopsys_run.tcl]
+  set SimulateOptions [concat {*}${ExtendedRunOptions} -ucli -do temp_Synopsys_run.tcl]
   puts "./simv ${SimulateOptions}" 
   set SimVErrorCode [catch {exec ./simv {*}${SimulateOptions}} SimulateErrorMessage]
 #  puts "SimVErrorCode $SimVErrorCode" ; # returns 0 on success


### PR DESCRIPTION
I have a added SynopsysGenericOptions to ElaborateOptions which fiixed an issue i had, where some system verilog components would not apply the string generics provided by a vhdl entity.