### PR TITLE
New feature and enhancement: Test titles, descriptions, tags and generics

### DIFF
--- a/CssOsvvmStyle.css
+++ b/CssOsvvmStyle.css
@@ -203,6 +203,18 @@ tfoot {
   text-align: right;
 }
 
+/* Datatype badges (used for Type columns: string/integer/boolean) */
+.datatype {
+    display: inline-block;
+    white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 0.95em;
+    padding: 0px 0.35em;
+    border: 1px solid #CCCCCC;
+    background-color: #f8f8f8;
+    border-radius: 3px;
+}
+
 summary > b {
     font-weight: bold;
 }

--- a/CssOsvvmStyle.css
+++ b/CssOsvvmStyle.css
@@ -144,7 +144,7 @@ table.testsuite-summary-table {
 /* Keep displayed suite title/name on one line in the Test Suite Summary table */
 table.testsuite-summary-table th:first-child,
 table.testsuite-summary-table td:first-child {
-    width: 1%;
+    /* width: 1%; */
     white-space: nowrap;
 }
 
@@ -291,11 +291,14 @@ h2.testcase-section-title .tc-suffix {
 /* Keep displayed test title/name on one line in the Test Case Summary table */
 table.testcase-summary-table {
     table-layout: auto;
+    display: inline-table;
+    width: auto;
+    max-width: 100%;
 }
 
 table.testcase-summary-table th:first-child,
 table.testcase-summary-table td:first-child {
-    width: 1%;
+    /* width: 1%; */
     white-space: nowrap;
 }
 

--- a/CssOsvvmStyle.css
+++ b/CssOsvvmStyle.css
@@ -46,9 +46,9 @@ body {
 header {
 }
 
-main {
+/* main {
     max-width: 1200px;
-}
+} */
 
 footer {
 }

--- a/CssOsvvmStyle.css
+++ b/CssOsvvmStyle.css
@@ -138,6 +138,18 @@ table, th, td {
 }
 
 table.testsuite-summary-table {
+    table-layout: auto;
+}
+
+/* Keep displayed suite title/name on one line in the Test Suite Summary table */
+table.testsuite-summary-table th:first-child,
+table.testsuite-summary-table td:first-child {
+    width: 1%;
+    white-space: nowrap;
+}
+
+table.testsuite-summary-table td:first-child a {
+    white-space: nowrap;
 }
 
 table.testsuite-details-table {
@@ -217,6 +229,78 @@ tfoot {
 
 summary > b {
     font-weight: bold;
+}
+
+/* Per-suite Test Case Summary heading: emphasize suite name, de-emphasize suffix */
+summary.suite-testcase-summary-heading {
+    font-weight: bold;
+}
+
+summary.suite-testcase-summary-heading .suite-name {
+    font-weight: bold;
+}
+
+summary.suite-testcase-summary-heading .suite-sep {
+    font-weight: bold;
+}
+
+summary.suite-testcase-summary-heading .suite-suffix {
+    font-weight: bold;
+    font-style: italic;
+    font-size: 0.95em;
+}
+
+/* Per-testcase report sections: "<test title> — Summary/Description/Tags/Generics" */
+summary.testcase-section-heading {
+    font-weight: bold;
+}
+
+summary.testcase-section-heading .tc-name {
+    font-weight: bold;
+}
+
+summary.testcase-section-heading .tc-sep {
+    font-weight: bold;
+}
+
+summary.testcase-section-heading .tc-suffix {
+    font-weight: bold;
+    font-style: italic;
+    font-size: 0.95em;
+}
+
+/* Section titles that are not <summary> (e.g. h2 Alert Report) */
+h2.testcase-section-title {
+    font-weight: bold;
+}
+
+h2.testcase-section-title .tc-name {
+    font-weight: bold;
+}
+
+h2.testcase-section-title .tc-sep {
+    font-weight: bold;
+}
+
+h2.testcase-section-title .tc-suffix {
+    font-weight: bold;
+    font-style: italic;
+    font-size: 0.95em;
+}
+
+/* Keep displayed test title/name on one line in the Test Case Summary table */
+table.testcase-summary-table {
+    table-layout: auto;
+}
+
+table.testcase-summary-table th:first-child,
+table.testcase-summary-table td:first-child {
+    width: 1%;
+    white-space: nowrap;
+}
+
+table.testcase-summary-table td:first-child a {
+    white-space: nowrap;
 }
 
 /* #logo {

--- a/OsvvmScriptsCore.tcl
+++ b/OsvvmScriptsCore.tcl
@@ -1425,12 +1425,52 @@ proc SetTestSuiteDescription {Description} {
 }
 
 # -------------------------------------------------
+# ClearTestSuiteDescription
+#   Clears any previously set suite-level description.
+proc ClearTestSuiteDescription {} {
+  set ::osvvm::TestSuiteDescription ""
+}
+
+# -------------------------------------------------
+# GetTestSuiteDescription
+#   Returns the currently configured suite-level description.
+proc GetTestSuiteDescription {} {
+  if {[info exists ::osvvm::TestSuiteDescription]} {
+    return $::osvvm::TestSuiteDescription
+  }
+  return ""
+}
+
+# -------------------------------------------------
 # SetTestSuiteBrief
 #   Sets a suite-level brief (plain text) for summary tables.
 #
 #   Call this after TestSuite <name> and before the suite finishes.
 proc SetTestSuiteBrief {Brief} {
+  if {![info exists ::osvvm::TestSuiteBriefMaxLength]} {
+    set ::osvvm::TestSuiteBriefMaxLength 120
+  }
+  if {$::osvvm::TestSuiteBriefMaxLength > 0 && [string length $Brief] > $::osvvm::TestSuiteBriefMaxLength} {
+    puts "Warning: SetTestSuiteBrief length ([string length $Brief]) exceeds TestSuiteBriefMaxLength ($::osvvm::TestSuiteBriefMaxLength)"
+  }
   set ::osvvm::TestSuiteBrief $Brief
+}
+
+# -------------------------------------------------
+# ClearTestSuiteBrief
+#   Clears any previously set suite-level brief.
+proc ClearTestSuiteBrief {} {
+  set ::osvvm::TestSuiteBrief ""
+}
+
+# -------------------------------------------------
+# GetTestSuiteBrief
+#   Returns the currently configured suite-level brief.
+proc GetTestSuiteBrief {} {
+  if {[info exists ::osvvm::TestSuiteBrief]} {
+    return $::osvvm::TestSuiteBrief
+  }
+  return ""
 }
 
 # -------------------------------------------------

--- a/OsvvmScriptsCore.tcl
+++ b/OsvvmScriptsCore.tcl
@@ -1434,6 +1434,36 @@ proc SetTestSuiteBrief {Brief} {
 }
 
 # -------------------------------------------------
+# Test Case Summary (HTML) Column Control
+#
+# These APIs control which columns are shown in the build HTML "<Suite> Test Case Summary" table.
+# Defaults:
+#   - Generics: visible (all generics found in the suite)
+#   - Tags: visible (all visible tags found in the suite)
+#
+# Notes:
+#   - Calling SetTestCaseSummaryGenerics with no args clears the whitelist (show all).
+#   - Calling SetTestCaseSummaryTags with no args clears the whitelist (show all tags found).
+
+proc SetTestCaseSummaryGenerics {args} {
+  set ::osvvm::TestCaseSummaryShowGenerics 1
+  set ::osvvm::TestCaseSummaryGenericNames $args
+}
+
+proc HideTestCaseSummaryGenerics {} {
+  set ::osvvm::TestCaseSummaryShowGenerics 0
+}
+
+proc SetTestCaseSummaryTags {args} {
+  set ::osvvm::TestCaseSummaryShowTags 1
+  set ::osvvm::TestCaseSummaryTagNames $args
+}
+
+proc HideTestCaseSummaryTags {} {
+  set ::osvvm::TestCaseSummaryShowTags 0
+}
+
+# -------------------------------------------------
 proc TestName {Name} {
   variable TestCaseName
   variable TestSuiteName

--- a/OsvvmScriptsCore.tcl
+++ b/OsvvmScriptsCore.tcl
@@ -1459,6 +1459,39 @@ proc SetTestSuiteBrief {Brief} {
 }
 
 # -------------------------------------------------
+# SetTestSuiteTitle
+#   Sets a suite-level title (human-friendly) for reports.
+#   The suite name remains the identifier.
+#
+#   Call this after TestSuite <name> and before the suite finishes.
+proc SetTestSuiteTitle {Title} {
+  if {![info exists ::osvvm::TestSuiteTitleMaxLength]} {
+    set ::osvvm::TestSuiteTitleMaxLength 80
+  }
+  if {$::osvvm::TestSuiteTitleMaxLength > 0 && [string length $Title] > $::osvvm::TestSuiteTitleMaxLength} {
+    puts "Warning: SetTestSuiteTitle length ([string length $Title]) exceeds TestSuiteTitleMaxLength ($::osvvm::TestSuiteTitleMaxLength)"
+  }
+  set ::osvvm::TestSuiteTitle $Title
+}
+
+# -------------------------------------------------
+# ClearTestSuiteTitle
+#   Clears any previously set suite-level title.
+proc ClearTestSuiteTitle {} {
+  set ::osvvm::TestSuiteTitle ""
+}
+
+# -------------------------------------------------
+# GetTestSuiteTitle
+#   Returns the currently configured suite-level title.
+proc GetTestSuiteTitle {} {
+  if {[info exists ::osvvm::TestSuiteTitle]} {
+    return $::osvvm::TestSuiteTitle
+  }
+  return ""
+}
+
+# -------------------------------------------------
 # ClearTestSuiteBrief
 #   Clears any previously set suite-level brief.
 proc ClearTestSuiteBrief {} {

--- a/OsvvmScriptsCore.tcl
+++ b/OsvvmScriptsCore.tcl
@@ -1262,9 +1262,11 @@ proc AfterSimulateReports {} {
   
   WriteTestCaseSettingsYaml $TestCaseSettingsFile
 
+  # FinishSimulateBuildYaml computes ElapsedTime and writes it to build YAML.
+  # It also appends ElapsedTime into the per-test *_run.yml so per-test HTML can display it.
+  FinishSimulateBuildYaml
+
   Simulate2Html $TestCaseSettingsFile
-  
-  FinishSimulateBuildYaml 
 }
 
 

--- a/OsvvmScriptsCore.tcl
+++ b/OsvvmScriptsCore.tcl
@@ -1415,6 +1415,25 @@ proc TestSuite {SuiteName} {
 }
 
 # -------------------------------------------------
+# SetTestSuiteDescription
+#   Sets a suite-level description which is written into the build YAML
+#   and displayed in the HTML "Test Suite Summary" Description column.
+#
+#   Call this after TestSuite <name> and before the suite finishes.
+proc SetTestSuiteDescription {Description} {
+  set ::osvvm::TestSuiteDescription $Description
+}
+
+# -------------------------------------------------
+# SetTestSuiteBrief
+#   Sets a suite-level brief (plain text) for summary tables.
+#
+#   Call this after TestSuite <name> and before the suite finishes.
+proc SetTestSuiteBrief {Brief} {
+  set ::osvvm::TestSuiteBrief $Brief
+}
+
+# -------------------------------------------------
 proc TestName {Name} {
   variable TestCaseName
   variable TestSuiteName

--- a/OsvvmScriptsCreateYamlReports.tcl
+++ b/OsvvmScriptsCreateYamlReports.tcl
@@ -432,13 +432,53 @@ proc FinishSimulateBuildYaml {} {
 
   set  SimulateFinishTimeMs  [clock milliseconds]
   set  SimulateElapsedTimeMs [expr ($SimulateFinishTimeMs - $SimulateStartTimeMs)]
+
+  set TestCaseElapsedTimeSeconds [format %.3f [expr ${SimulateElapsedTimeMs}/1000.0]]
   
   set RunFile [open ${::osvvm::OsvvmTempYamlFile} a]
   puts  $RunFile "        TestCaseFileName: \"$TestCaseFileName\""
   WriteDictOfDict2Yaml $RunFile Generics $::osvvm::GenericDict  "        "
 #  puts  $RunFile "        TestCaseGenerics: \"$::osvvm::GenericDict\""
-  puts  $RunFile "        ElapsedTime: [format %.3f [expr ${SimulateElapsedTimeMs}/1000.0]]"
+  puts  $RunFile "        ElapsedTime: $TestCaseElapsedTimeSeconds"
   close $RunFile
+
+  # Make per-test reports self-contained: add ElapsedTime to the per-test *_run.yml
+  # so per-test HTML does not require joining the suite/build YAML.
+  AppendElapsedTimeToTestCaseSettingsYaml $TestCaseElapsedTimeSeconds
+}
+
+# -------------------------------------------------
+# AppendElapsedTimeToTestCaseSettingsYaml
+#
+# Adds a top-level ElapsedTime key to the per-test *_run.yml (if not already present).
+# This is safe to call after WriteTestCaseSettingsYaml has created the file.
+proc AppendElapsedTimeToTestCaseSettingsYaml {ElapsedTimeSeconds} {
+  variable TestCaseFileName
+
+  if {![info exists ::osvvm::ReportsTestSuiteDirectory] || $::osvvm::ReportsTestSuiteDirectory eq ""} {
+    return
+  }
+  if {![info exists TestCaseFileName] || $TestCaseFileName eq ""} {
+    return
+  }
+
+  set SettingsFileName [file join $::osvvm::ReportsTestSuiteDirectory ${TestCaseFileName}_run.yml]
+  if {![file exists $SettingsFileName]} {
+    return
+  }
+
+  # Avoid duplicate keys if rerun.
+  set InFile [open $SettingsFileName r]
+  set Contents [read $InFile]
+  close $InFile
+  if {[regexp {(?m)^ElapsedTime\s*:} $Contents]} {
+    return
+  }
+
+  set OutFile [open $SettingsFileName a]
+  puts $OutFile ""
+  puts $OutFile "ElapsedTime: $ElapsedTimeSeconds"
+  close $OutFile
 }
 
 # -------------------------------------------------

--- a/OsvvmScriptsCreateYamlReports.tcl
+++ b/OsvvmScriptsCreateYamlReports.tcl
@@ -48,6 +48,52 @@ namespace eval ::osvvm {
 package require fileutil
 
 
+# -------------------------------------------------
+# FormatYamlScalar
+#   Return a YAML scalar string that uses native types when safe:
+#     - empty -> null (empty scalar)
+#     - true/false (case-insensitive, also accepts TRUE/FALSE)
+#     - integer / float
+#   Otherwise returns a double-quoted string with minimal escaping.
+#
+proc FormatYamlScalar {Value} {
+  # Treat unset/missing as empty
+  if {$Value eq ""} {
+    return "null"
+  }
+
+  set Trimmed [string trim $Value]
+  if {$Trimmed eq ""} {
+    return "\"$Value\""
+  }
+
+  # null
+  if {[string equal -nocase $Trimmed "null"]} {
+    return "null"
+  }
+
+  # boolean
+  if {[string equal -nocase $Trimmed "true"] || [string equal -nocase $Trimmed "false"]} {
+    return [string tolower $Trimmed]
+  }
+
+  # integer
+  if {[regexp {^[-+]?\d+$} $Trimmed]} {
+    return $Trimmed
+  }
+
+  # float (simple forms, incl exponent)
+  if {[regexp {^[-+]?(?:\d+\.\d*|\d*\.\d+)(?:[eE][-+]?\d+)?$} $Trimmed] || [regexp {^[-+]?\d+(?:[eE][-+]?\d+)$} $Trimmed]} {
+    return $Trimmed
+  }
+
+  # default: quoted string
+  # Use [list] to avoid Tcl list parsing edge cases
+  set Escaped [string map [list "\\" "\\\\" "\"" "\\\""] $Value]
+  return "\"$Escaped\""
+}
+
+
   variable  TclZone      [clock format [clock seconds] -format %z]
   variable  IsoZone      [format "%s:%s" [string range $TclZone 0 2] [string range $TclZone 3 4]] 
 #  variable  TimeZoneName [clock format [clock seconds] -format %Z]
@@ -198,7 +244,7 @@ proc WriteDictOfDict2Yaml {YamlFile DictName {DictValues ""} {Prefix ""} } {
   } else {
     puts $YamlFile "${Prefix}${DictName}:"
     foreach {Name Value} $DictValues {
-      puts $YamlFile "${Prefix}  ${Name}: \"$Value\""
+      puts $YamlFile "${Prefix}  ${Name}: [FormatYamlScalar $Value]"
     }
   }
 }
@@ -292,6 +338,10 @@ proc WriteTestCaseSettingsYaml {FileName} {
 # -------------------------------------------------
 proc StartTestSuiteBuildYaml {SuiteName FirstRun} {
   variable TestSuiteStartTimeMs
+  # Suite-level description is set by user scripts (ex: .pro files)
+  # using ::osvvm::TestSuiteDescription.
+  set ::osvvm::TestSuiteDescription ""
+  set ::osvvm::TestSuiteBrief ""
   
   set RunFile [open ${::osvvm::OsvvmTempYamlFile} a]
 
@@ -313,6 +363,12 @@ proc FinishTestSuiteBuildYaml {} {
   variable TestSuiteStartTimeMs
 
   set   RunFile  [open ${::osvvm::OsvvmTempYamlFile} a]
+  if {[info exists ::osvvm::TestSuiteBrief] && $::osvvm::TestSuiteBrief ne ""} {
+    WriteDictOfString2Yaml $RunFile Brief $::osvvm::TestSuiteBrief "    "
+  }
+  if {[info exists ::osvvm::TestSuiteDescription] && $::osvvm::TestSuiteDescription ne ""} {
+    WriteDictOfString2Yaml $RunFile Description $::osvvm::TestSuiteDescription "    "
+  }
   puts  $RunFile "    ElapsedTime: [ElapsedTimeMs $TestSuiteStartTimeMs]"
   close $RunFile
 }

--- a/OsvvmScriptsCreateYamlReports.tcl
+++ b/OsvvmScriptsCreateYamlReports.tcl
@@ -49,6 +49,21 @@ package require fileutil
 
 
 # -------------------------------------------------
+# SanitizeTextForReport
+#   Removes ASCII control characters (except \t, \n, \r) that can break YAML/HTML.
+#   This does not attempt full UTF-8 validation; Tcl strings are Unicode.
+proc SanitizeTextForReport {Text} {
+  if {$Text eq ""} {
+    return ""
+  }
+  # Strip C0 controls excluding tab/newline/carriage return, plus DEL.
+  #   - \x00-\x08, \x0B-\x0C, \x0E-\x1F, \x7F
+  regsub -all {[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]} $Text { } Clean
+  return $Clean
+}
+
+
+# -------------------------------------------------
 # FormatYamlScalar
 #   Return a YAML scalar string that uses native types when safe:
 #     - empty -> null (empty scalar)
@@ -62,9 +77,12 @@ proc FormatYamlScalar {Value} {
     return "null"
   }
 
+  set Value [SanitizeTextForReport $Value]
   set Trimmed [string trim $Value]
   if {$Trimmed eq ""} {
-    return "\"$Value\""
+    # Keep whitespace-only values as strings
+    set Escaped [string map [list "\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t"] $Value]
+    return "\"$Escaped\""
   }
 
   # null
@@ -89,7 +107,17 @@ proc FormatYamlScalar {Value} {
 
   # default: quoted string
   # Use [list] to avoid Tcl list parsing edge cases
-  set Escaped [string map [list "\\" "\\\\" "\"" "\\\""] $Value]
+  set Escaped [string map [list "\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t"] $Value]
+  return "\"$Escaped\""
+}
+
+
+# -------------------------------------------------
+# FormatYamlDoubleQuotedScalar
+#   Always returns a double-quoted YAML string (never native/null).
+proc FormatYamlDoubleQuotedScalar {Value} {
+  set Value [SanitizeTextForReport $Value]
+  set Escaped [string map [list "\\" "\\\\" "\"" "\\\"" "\n" "\\n" "\r" "\\r" "\t" "\\t"] $Value]
   return "\"$Escaped\""
 }
 
@@ -243,7 +271,8 @@ proc WriteDictOfDict2Yaml {YamlFile DictName {DictValues ""} {Prefix ""} } {
 #    puts $YamlFile "${Prefix}${DictName}:            \"\""
   } else {
     puts $YamlFile "${Prefix}${DictName}:"
-    foreach {Name Value} $DictValues {
+    foreach Name [lsort -dictionary [dict keys $DictValues]] {
+      set Value [dict get $DictValues $Name]
       puts $YamlFile "${Prefix}  ${Name}: [FormatYamlScalar $Value]"
     }
   }
@@ -263,7 +292,7 @@ proc WriteDictOfList2Yaml {YamlFile DictName {ListValues ""} {Prefix ""} } {
 
 # -------------------------------------------------
 proc WriteDictOfString2Yaml {YamlFile DictName {StringValue ""} {Prefix ""} } {
-  puts $YamlFile "${Prefix}${DictName}: \"$StringValue\""
+  puts $YamlFile "${Prefix}${DictName}: [FormatYamlDoubleQuotedScalar $StringValue]"
 }
 
 # -------------------------------------------------

--- a/OsvvmScriptsCreateYamlReports.tcl
+++ b/OsvvmScriptsCreateYamlReports.tcl
@@ -370,6 +370,7 @@ proc StartTestSuiteBuildYaml {SuiteName FirstRun} {
   # Suite-level description is set by user scripts (ex: .pro files)
   # using ::osvvm::TestSuiteDescription.
   set ::osvvm::TestSuiteDescription ""
+  set ::osvvm::TestSuiteTitle ""
   set ::osvvm::TestSuiteBrief ""
   
   set RunFile [open ${::osvvm::OsvvmTempYamlFile} a]
@@ -392,6 +393,9 @@ proc FinishTestSuiteBuildYaml {} {
   variable TestSuiteStartTimeMs
 
   set   RunFile  [open ${::osvvm::OsvvmTempYamlFile} a]
+  if {[info exists ::osvvm::TestSuiteTitle] && $::osvvm::TestSuiteTitle ne ""} {
+    WriteDictOfString2Yaml $RunFile Title $::osvvm::TestSuiteTitle "    "
+  }
   if {[info exists ::osvvm::TestSuiteBrief] && $::osvvm::TestSuiteBrief ne ""} {
     WriteDictOfString2Yaml $RunFile Brief $::osvvm::TestSuiteBrief "    "
   }

--- a/OsvvmSettingsRequired.tcl
+++ b/OsvvmSettingsRequired.tcl
@@ -65,6 +65,18 @@ namespace eval ::osvvm {
   variable OsvvmScoreboardYamlVersion   InVhdlCodeVersionTbd
   variable OsvvmRequirementsYamlVersion InVhdlCodeVersionTbd   ;# file is an array of requirements - version not possible w/o file change
 
+  # -------------------------------------------------
+  # Brief length guard (soft warning)
+  # 0 disables warning.
+  variable TestSuiteBriefMaxLength 120
+
+  # -------------------------------------------------
+  # Test Case Summary (HTML) column limits
+  # These caps prevent the summary table from becoming too wide when many generics/tags exist.
+  # 0 (or negative) disables the cap.
+  variable TestCaseSummaryMaxGenericsColumns 12
+  variable TestCaseSummaryMaxTagsColumns     12
+
   if {![info exists OsvvmVersionCompatibility]} {
     variable OsvvmVersionCompatibility $OsvvmVersion
   }

--- a/ReportAlert2Html.tcl
+++ b/ReportAlert2Html.tcl
@@ -66,6 +66,18 @@ proc LocalAlert2Html {TestCaseName TestSuiteName AlertYamlFile} {
   
   AlertSettings $Alert2HtmlDict
   
+  # Extract and store Description and Tags for use in other reports
+  if {[dict exists $Alert2HtmlDict Description]} {
+    set ::osvvm::Report2TestDescription [dict get $Alert2HtmlDict Description]
+  } else {
+    set ::osvvm::Report2TestDescription ""
+  }
+  if {[dict exists $Alert2HtmlDict Tags]} {
+    set ::osvvm::Report2TestTags [dict get $Alert2HtmlDict Tags]
+  } else {
+    set ::osvvm::Report2TestTags ""
+  }
+  
   CreateAlertResultsHeader $TestCaseName
   
   AlertWrite $Alert2HtmlDict

--- a/ReportAlert2Html.tcl
+++ b/ReportAlert2Html.tcl
@@ -89,16 +89,6 @@ proc LocalAlert2Html {TestCaseName TestSuiteName AlertYamlFile} {
   } else {
     set ::osvvm::Report2TestTags ""
   }
-  if {[dict exists $Alert2HtmlDict TagSummaryVisibility]} {
-    set ::osvvm::Report2TestTagSummaryVisibility [dict get $Alert2HtmlDict TagSummaryVisibility]
-  } else {
-    set ::osvvm::Report2TestTagSummaryVisibility ""
-  }
-  if {[dict exists $Alert2HtmlDict TagTypes]} {
-    set ::osvvm::Report2TestTagTypes [dict get $Alert2HtmlDict TagTypes]
-  } else {
-    set ::osvvm::Report2TestTagTypes ""
-  }
   
   CreateAlertResultsHeader $DisplayName
   

--- a/ReportAlert2Html.tcl
+++ b/ReportAlert2Html.tcl
@@ -89,6 +89,16 @@ proc LocalAlert2Html {TestCaseName TestSuiteName AlertYamlFile} {
   } else {
     set ::osvvm::Report2TestTags ""
   }
+  if {[dict exists $Alert2HtmlDict TagSummaryVisibility]} {
+    set ::osvvm::Report2TestTagSummaryVisibility [dict get $Alert2HtmlDict TagSummaryVisibility]
+  } else {
+    set ::osvvm::Report2TestTagSummaryVisibility ""
+  }
+  if {[dict exists $Alert2HtmlDict TagTypes]} {
+    set ::osvvm::Report2TestTagTypes [dict get $Alert2HtmlDict TagTypes]
+  } else {
+    set ::osvvm::Report2TestTagTypes ""
+  }
   
   CreateAlertResultsHeader $DisplayName
   

--- a/ReportAlert2Html.tcl
+++ b/ReportAlert2Html.tcl
@@ -63,8 +63,20 @@ proc LocalAlert2Html {TestCaseName TestSuiteName AlertYamlFile} {
   variable ResultsFile
 
   set Alert2HtmlDict [::yaml::yaml2dict -file ${AlertYamlFile}]
+
+  # Prefer Title (if set) for visible headings; fall back to YAML Name.
+  set DisplayName ""
+  if {[dict exists $Alert2HtmlDict Name]} {
+    set DisplayName [dict get $Alert2HtmlDict Name]
+  }
+  if {[dict exists $Alert2HtmlDict Title]} {
+    set CandidateTitle [string trim [dict get $Alert2HtmlDict Title]]
+    if {$CandidateTitle ne ""} {
+      set DisplayName $CandidateTitle
+    }
+  }
   
-  AlertSettings $Alert2HtmlDict
+  AlertSettings $Alert2HtmlDict $DisplayName
   
   # Extract and store Description and Tags for use in other reports
   if {[dict exists $Alert2HtmlDict Description]} {
@@ -78,17 +90,20 @@ proc LocalAlert2Html {TestCaseName TestSuiteName AlertYamlFile} {
     set ::osvvm::Report2TestTags ""
   }
   
-  CreateAlertResultsHeader $TestCaseName
+  CreateAlertResultsHeader $DisplayName
   
   AlertWrite $Alert2HtmlDict
   
   CreateAlertResultsFooter
 }
 
-proc AlertSettings {AlertDict} {
+proc AlertSettings {AlertDict {DisplayName ""}} {
   variable ResultsFile
-  
+
   set Name     [dict get $AlertDict Name]
+  if {$DisplayName eq ""} {
+    set DisplayName $Name
+  }
   set Settings [dict get $AlertDict Settings]
   set External [dict get $Settings ExternalErrors]
   set Failure [dict get $External Failure]
@@ -103,9 +118,9 @@ proc AlertSettings {AlertDict} {
 
   puts $ResultsFile "  <hr />"
   puts $ResultsFile "  <div class=\"AlertSummary\">"
-  puts $ResultsFile "    <h2 id=\"AlertSummary\">$Name Alert Report</h2>"
+  puts $ResultsFile "    <h2 id=\"AlertSummary\" class=\"testcase-section-title\"><span class=\"tc-name\">[EscapeHtml $DisplayName]</span><span class=\"tc-sep\"> — </span><span class=\"tc-suffix\">Alert Report</span></h2>"
   puts $ResultsFile "    <div class=\"AlertSettings\">"
-  puts $ResultsFile "      <details open><summary class=\"subtitle\">$Name Alert Settings</summary>"
+  puts $ResultsFile "      <details open><summary class=\"subtitle testcase-section-heading\"><span class=\"tc-name\">[EscapeHtml $DisplayName]</span><span class=\"tc-sep\"> — </span><span class=\"tc-suffix\">Alert Settings</span></summary>"
   puts $ResultsFile "        <table class=\"AlertSettings\">"
   puts $ResultsFile "          <thead>"
   puts $ResultsFile "            <tr>"
@@ -168,7 +183,7 @@ proc CreateAlertResultsHeader {TestCaseName} {
   variable ResultsFile
   
   puts $ResultsFile "    <div class=\"AlertResults\">"
-  puts $ResultsFile "      <details open><summary class=\"subtitle\">$TestCaseName Alert Results</summary>"
+  puts $ResultsFile "      <details open><summary class=\"subtitle testcase-section-heading\"><span class=\"tc-name\">[EscapeHtml $TestCaseName]</span><span class=\"tc-sep\"> — </span><span class=\"tc-suffix\">Alert Results</span></summary>"
   puts $ResultsFile "        <table class=\"AlertResults\">"
   puts $ResultsFile "          <thead>"
   puts $ResultsFile "            <tr>"
@@ -206,6 +221,13 @@ proc AlertWrite {AlertDict {Prefix ""}} {
     set DisabledAlertCount   [dict get $Results      DisabledAlertCount]
 
     set Name                 [dict get $AlertDict          Name]
+    set DisplayName $Name
+    if {$Prefix eq "" && [dict exists $AlertDict Title]} {
+      set CandidateTitle [string trim [dict get $AlertDict Title]]
+      if {$CandidateTitle ne ""} {
+        set DisplayName $CandidateTitle
+      }
+    }
     set Status               [dict get $AlertDict          Status]
     set PassedCount          [dict get $Results            PassedCount]
     set AffirmCount          [dict get $Results            AffirmCount]
@@ -284,7 +306,7 @@ proc AlertWrite {AlertDict {Prefix ""}} {
     }
 
     puts $ResultsFile "            <tr>"
-    puts $ResultsFile "              <td>${Prefix}${Name}</td>"
+    puts $ResultsFile "              <td>${Prefix}${DisplayName}</td>"
     puts $ResultsFile "              <td ${StatusClass}>$Status</td>"
     puts $ResultsFile "              <td ${PassedCountClass}>$AffirmCount</td>"
     puts $ResultsFile "              <td ${PassedCountClass}>$PassedCount</td>"

--- a/ReportBuildDict2Html.tcl
+++ b/ReportBuildDict2Html.tcl
@@ -322,6 +322,12 @@ proc CreateTestCaseSummaries {TestDict} {
         set ConfigGenericWhitelist $::osvvm::TestCaseSummaryGenericNames
       }
 
+      # Default: cap the number of generic columns to keep tables readable.
+      set ConfigMaxGenericsColumns 0
+      if {[info exists ::osvvm::TestCaseSummaryMaxGenericsColumns]} {
+        set ConfigMaxGenericsColumns $::osvvm::TestCaseSummaryMaxGenericsColumns
+      }
+
       # Default: show tags in the Test Case Summary table
       set ConfigShowTags 1
       if {[info exists ::osvvm::TestCaseSummaryShowTags]} {
@@ -330,6 +336,12 @@ proc CreateTestCaseSummaries {TestDict} {
       set ConfigTagWhitelist {}
       if {[info exists ::osvvm::TestCaseSummaryTagNames]} {
         set ConfigTagWhitelist $::osvvm::TestCaseSummaryTagNames
+      }
+
+      # Default: cap the number of tag columns to keep tables readable.
+      set ConfigMaxTagsColumns 0
+      if {[info exists ::osvvm::TestCaseSummaryMaxTagsColumns]} {
+        set ConfigMaxTagsColumns $::osvvm::TestCaseSummaryMaxTagsColumns
       }
 
       # Collect a stable list of generic names used by any test case in this suite.
@@ -364,6 +376,13 @@ proc CreateTestCaseSummaries {TestDict} {
       set SuiteGenericCount [llength $SuiteGenericNames]
       set SuiteGenericCountAll [llength $SuiteGenericNamesAll]
 
+      # Enforce max generics columns (0/negative => unlimited)
+      if {$SuiteGenericCount > 0 && $ConfigMaxGenericsColumns > 0 && $SuiteGenericCount > $ConfigMaxGenericsColumns} {
+        puts "Warning: Test Case Summary generics columns truncated from $SuiteGenericCount to $ConfigMaxGenericsColumns for suite $SuiteName"
+        set SuiteGenericNames [lrange $SuiteGenericNames 0 [expr {$ConfigMaxGenericsColumns - 1}]]
+        set SuiteGenericCount [llength $SuiteGenericNames]
+      }
+
       # Collect tag names (stable order) and determine visibility across all testcases.
       # A tag column is included if the tag is visible in ANY testcase.
       set SuiteTagNamesAll {}
@@ -381,8 +400,8 @@ proc CreateTestCaseSummaries {TestDict} {
 
                 # Per-tag visibility for this testcase (default visible).
                 set IsVisible 1
-                if {[dict exists $TcForTags TagVisibility]} {
-                  set VisDict [dict get $TcForTags TagVisibility]
+                if {[dict exists $TcForTags TagSummaryVisibility]} {
+                  set VisDict [dict get $TcForTags TagSummaryVisibility]
                   if {![catch {dict size $VisDict}]} {
                     if {[dict exists $VisDict $TagName]} {
                       set VisVal [dict get $VisDict $TagName]
@@ -429,6 +448,13 @@ proc CreateTestCaseSummaries {TestDict} {
         }
       }
       set SuiteTagCount [llength $SuiteTagNames]
+
+      # Enforce max tags columns (0/negative => unlimited)
+      if {$SuiteTagCount > 0 && $ConfigMaxTagsColumns > 0 && $SuiteTagCount > $ConfigMaxTagsColumns} {
+        puts "Warning: Test Case Summary tag columns truncated from $SuiteTagCount to $ConfigMaxTagsColumns for suite $SuiteName"
+        set SuiteTagNames [lrange $SuiteTagNames 0 [expr {$ConfigMaxTagsColumns - 1}]]
+        set SuiteTagCount [llength $SuiteTagNames]
+      }
 
       puts $ResultsFile "  <div class=\"testcase\">"
       puts $ResultsFile "    <details open><summary id=\"$SuiteName\">$SuiteName Test Case Summary</summary>"
@@ -574,7 +600,7 @@ proc CreateTestCaseSummaries {TestDict} {
               set GenValue "⸻"
             }
             set GenDisplayValue [FormatGenericValueForHtml $GenName $GenValue $TestFileName]
-            puts $ResultsFile "            <td style=\"text-align: center;\">$GenDisplayValue</td>"
+            puts $ResultsFile "            <td style=\"text-align: right;\">$GenDisplayValue</td>"
           }
         }
 
@@ -590,7 +616,7 @@ proc CreateTestCaseSummaries {TestDict} {
             set HasTags 1
           }
           foreach TagName $SuiteTagNames {
-            # TagVisibility is used only to decide whether a tag column exists.
+            # TagSummaryVisibility is used only to decide whether a tag column exists.
             # If the column exists (visible in any testcase), then show the tag
             # value for every testcase that has it.
             if { $HasTags && [dict exists $TestCaseTags $TagName] } {
@@ -599,7 +625,7 @@ proc CreateTestCaseSummaries {TestDict} {
             } else {
               set TagDisplay "⸻"
             }
-            puts $ResultsFile "            <td style=\"text-align: left;\">$TagDisplay</td>"
+            puts $ResultsFile "            <td style=\"text-align: right;\">$TagDisplay</td>"
           }
         }
 

--- a/ReportBuildDict2Html.tcl
+++ b/ReportBuildDict2Html.tcl
@@ -223,6 +223,15 @@ proc CreateTestSuiteSummary  {} {
   variable ReportBuildName
 
   if { $HaveTestSuites } {
+    # Show Brief column only when at least one suite explicitly sets Brief.
+    set ShowSuiteBriefCol 0
+    foreach TsForBrief $TestSuiteSummaryArrayOfDictionaries {
+      if { [dict exists $TsForBrief Brief] && [string trim [dict get $TsForBrief Brief]] ne "" } {
+        set ShowSuiteBriefCol 1
+        break
+      }
+    }
+
     puts $ResultsFile "  <div class=\"testsuite\">"
     puts $ResultsFile "    <details open=\"open\" class=\"testsuite-details\"><summary>Test Suite Summary</summary>"
     puts $ResultsFile "      <table class=\"testsuite-summary-table\">"
@@ -233,7 +242,9 @@ proc CreateTestSuiteSummary  {} {
     puts $ResultsFile "              <th rowspan=\"2\">Requirements<br>passed / goal</th>"
     puts $ResultsFile "              <th rowspan=\"2\">Disabled<br>Alerts</th>"
     puts $ResultsFile "              <th rowspan=\"2\">Elapsed<br>Time</th>"
-    puts $ResultsFile "              <th rowspan=\"2\" style=\"width: 50%; text-align: center;\">Brief</th>"
+    if {$ShowSuiteBriefCol} {
+      puts $ResultsFile "              <th rowspan=\"2\" style=\"width: 50%; text-align: center;\">Brief</th>"
+    }
     puts $ResultsFile "          </tr>"
     puts $ResultsFile "          <tr>"
     puts $ResultsFile "              <th>PASSED </th>"
@@ -245,12 +256,16 @@ proc CreateTestSuiteSummary  {} {
 
     foreach TestSuite $TestSuiteSummaryArrayOfDictionaries {
       set SuiteName [dict get $TestSuite Name]
+      set SuiteDisplayName $SuiteName
+      if {[dict exists $TestSuite Title]} {
+        set CandidateTitle [string trim [dict get $TestSuite Title]]
+        if {$CandidateTitle ne ""} {
+          set SuiteDisplayName $CandidateTitle
+        }
+      }
       set SuiteStatus  [dict get $TestSuite Status]
-      if { [dict exists $TestSuite Brief] } {
+      if {$ShowSuiteBriefCol && [dict exists $TestSuite Brief]} {
         set SuiteBrief [dict get $TestSuite Brief]
-      } elseif { [dict exists $TestSuite Description] } {
-        # Backward compatibility: use first line of Description
-        set SuiteBrief [lindex [split [dict get $TestSuite Description] "\n"] 0]
       } else {
         set SuiteBrief ""
       }
@@ -268,7 +283,7 @@ proc CreateTestSuiteSummary  {} {
       }
 
       puts $ResultsFile "          <tr>"
-      puts $ResultsFile "            <td><a href=\"#${SuiteName}\">${SuiteName}</a></td>"
+      puts $ResultsFile "            <td><a href=\"#${SuiteName}\">[EscapeHtml ${SuiteDisplayName}]</a></td>"
       puts $ResultsFile "            <td ${StatusClass}>$SuiteStatus</td>"
       puts $ResultsFile "            <td ${PassedClass}>[dict get $TestSuite PASSED] </td>"
       puts $ResultsFile "            <td ${FailedClass}>[dict get $TestSuite FAILED] </td>"
@@ -288,11 +303,13 @@ proc CreateTestSuiteSummary  {} {
       }
       puts $ResultsFile "          <td>[dict get $TestSuite DisabledAlerts]</td>"
       puts $ResultsFile "          <td>[dict get $TestSuite ElapsedTime]</td>"
-      puts $ResultsFile "          <td style=\"text-align: left;\">"
-      if {${SuiteBrief} ne ""} {
-        puts $ResultsFile "            [EscapeHtml $SuiteBrief]"
+      if {$ShowSuiteBriefCol} {
+        puts $ResultsFile "          <td style=\"text-align: left;\">"
+        if {${SuiteBrief} ne ""} {
+          puts $ResultsFile "            [EscapeHtml $SuiteBrief]"
+        }
+        puts $ResultsFile "          </td>"
       }
-      puts $ResultsFile "          </td>"
       puts $ResultsFile "        </tr>"
     }
     puts $ResultsFile "        </tbody>"
@@ -311,6 +328,22 @@ proc CreateTestCaseSummaries {TestDict} {
   if { [dict exists $TestDict TestSuites] } {
     foreach TestSuite [dict get $TestDict TestSuites] {
       set SuiteName [dict get $TestSuite Name]
+      set SuiteDisplayName $SuiteName
+      if {[dict exists $TestSuite Title]} {
+        set CandidateTitle [string trim [dict get $TestSuite Title]]
+        if {$CandidateTitle ne ""} {
+          set SuiteDisplayName $CandidateTitle
+        }
+      }
+
+      # Show Brief column only when at least one testcase explicitly sets Brief.
+      set ShowTestBriefCol 0
+      foreach TcForBrief [dict get $TestSuite TestCases] {
+        if { [dict exists $TcForBrief Brief] && [string trim [dict get $TcForBrief Brief]] ne "" } {
+          set ShowTestBriefCol 1
+          break
+        }
+      }
 
       # Configuration hooks (set via OSVVM-Scripts/OsvvmScriptsCore.tcl APIs)
       set ConfigShowGenerics 1
@@ -457,7 +490,7 @@ proc CreateTestCaseSummaries {TestDict} {
       }
 
       puts $ResultsFile "  <div class=\"testcase\">"
-      puts $ResultsFile "    <details open><summary id=\"$SuiteName\">$SuiteName Test Case Summary</summary>"
+      puts $ResultsFile "    <details open class=\"suite-testcase-summary\"><summary id=\"$SuiteName\" class=\"suite-testcase-summary-heading\"><span class=\"suite-name\">[EscapeHtml $SuiteDisplayName]</span><span class=\"suite-sep\"> — </span><span class=\"suite-suffix\">Test Case Summary</span></summary>"
       puts $ResultsFile "      <table class=\"testcase-summary-table\">"
       puts $ResultsFile "        <thead>"
       puts $ResultsFile "          <tr><th rowspan=\"2\">Test Case</th>"
@@ -473,7 +506,9 @@ proc CreateTestCaseSummaries {TestDict} {
       puts $ResultsFile "              <th rowspan=\"2\">Functional<br>Coverage</th>"
       puts $ResultsFile "              <th rowspan=\"2\">Disabled<br>Alerts</th>"
       puts $ResultsFile "              <th rowspan=\"2\">Elapsed<br>Time</th>"
-      puts $ResultsFile "              <th rowspan=\"2\" style=\"width: 50%; text-align: center;\">Brief</th>"
+      if {$ShowTestBriefCol} {
+        puts $ResultsFile "              <th rowspan=\"2\" style=\"width: 50%; text-align: center;\">Brief</th>"
+      }
       puts $ResultsFile "          </tr>"
       puts $ResultsFile "          <tr>"
       if { $SuiteGenericCount > 0 } {
@@ -499,12 +534,19 @@ proc CreateTestCaseSummaries {TestDict} {
 
       foreach TestCase [dict get $TestSuite TestCases] {
         set TestName     [dict get $TestCase TestCaseName]
-        # Get test brief if available
-        if { [dict exists $TestCase Brief] } {
+
+        # Display title in the Name column when explicitly set.
+        set DisplayName $TestName
+        if {[dict exists $TestCase Title]} {
+          set CandidateTitle [string trim [dict get $TestCase Title]]
+          if {$CandidateTitle ne ""} {
+            set DisplayName $CandidateTitle
+          }
+        }
+
+        # Get test brief only if explicitly set
+        if {$ShowTestBriefCol && [dict exists $TestCase Brief]} {
           set TestBrief [dict get $TestCase Brief]
-        } elseif { [dict exists $TestCase Description] } {
-          # Backward compatibility: use first line of Description
-          set TestBrief [lindex [split [dict get $TestCase Description] "\n"] 0]
         } else {
           set TestBrief ""
         }
@@ -560,6 +602,7 @@ proc CreateTestCaseSummaries {TestDict} {
         }
         set TestCaseHtmlFile [file join ${TestSuiteReportsDirectory} ${TestFileName}.html]
         set TestCaseName $TestName
+        set DisplayNameWithGenerics $DisplayName
         # Backward compatibility: if there are no generic columns, append generic values to the Test Case name.
         # Do this only when the suite truly has no generics (not when generics are hidden via config).
         if { ($SuiteGenericCountAll == 0) && [dict exists $TestCase Generics] } {
@@ -569,18 +612,21 @@ proc CreateTestCaseSummaries {TestDict} {
             set i 0
             set ListLen [llength ${GenericValueList}]
             append TestCaseName " ("
+            append DisplayNameWithGenerics " ("
             foreach GenericValue $GenericValueList {
               incr i
               if {$i != $ListLen} {
                 append TestCaseName $GenericValue " ,"
+                append DisplayNameWithGenerics $GenericValue " ,"
               } else {
                 append TestCaseName $GenericValue ")"
+                append DisplayNameWithGenerics $GenericValue ")"
               }
             }
           }
         }
         puts $ResultsFile "          <tr>"
-        puts $ResultsFile "            <td><a href=\"${TestCaseHtmlFile}\">${TestCaseName}</a></td>"
+        puts $ResultsFile "            <td><a href=\"${TestCaseHtmlFile}\">${DisplayNameWithGenerics}</a></td>"
 
         # Generics are the second column group (after Test Case name).
         if { $SuiteGenericCount > 0 } {
@@ -660,14 +706,16 @@ proc CreateTestCaseSummaries {TestDict} {
             set TestCaseElapsedTime missing
           }
           puts $ResultsFile "            <td>$TestCaseElapsedTime</td>"
-          puts $ResultsFile "            <td style=\"text-align: left;\">"
-          if {${TestBrief} ne ""} {
-            puts $ResultsFile "              [EscapeHtml $TestBrief]"
+          if {$ShowTestBriefCol} {
+            puts $ResultsFile "            <td style=\"text-align: left;\">"
+            if {${TestBrief} ne ""} {
+              puts $ResultsFile "              [EscapeHtml $TestBrief]"
+            }
+            puts $ResultsFile "            </td>"
           }
-          puts $ResultsFile "            </td>"
         } else {
           # Remaining columns after Test Case + (optional Generics) + Status
-          set RemainingColumns 9
+          set RemainingColumns [expr {8 + ($ShowTestBriefCol ? 1 : 0)}]
           puts $ResultsFile "            <td style=\"text-align: left\" colspan=\"$RemainingColumns\"> &emsp; $Reason</td>"
         }
         puts $ResultsFile "          </tr>"

--- a/ReportBuildDict2Html.tcl
+++ b/ReportBuildDict2Html.tcl
@@ -432,15 +432,15 @@ proc CreateTestCaseSummaries {TestDict} {
                 }
 
                 # Per-tag visibility for this testcase (default visible).
+                # New schema: Tags(tag).Visibility.Summary
                 set IsVisible 1
-                if {[dict exists $TcForTags TagSummaryVisibility]} {
-                  set VisDict [dict get $TcForTags TagSummaryVisibility]
-                  if {![catch {dict size $VisDict}]} {
-                    if {[dict exists $VisDict $TagName]} {
-                      set VisVal [dict get $VisDict $TagName]
-                      if {$VisVal eq 0 || $VisVal eq "0" || [string equal -nocase $VisVal "false"]} {
-                        set IsVisible 0
-                      }
+                set TagRec [dict get $TagsDict $TagName]
+                if {![catch {dict size $TagRec}] && [dict exists $TagRec Visibility]} {
+                  set VisRec [dict get $TagRec Visibility]
+                  if {![catch {dict size $VisRec}] && [dict exists $VisRec Summary]} {
+                    set VisVal [dict get $VisRec Summary]
+                    if {$VisVal eq 0 || $VisVal eq "0" || [string equal -nocase $VisVal "false"]} {
+                      set IsVisible 0
                     }
                   }
                 }
@@ -662,11 +662,14 @@ proc CreateTestCaseSummaries {TestDict} {
             set HasTags 1
           }
           foreach TagName $SuiteTagNames {
-            # TagSummaryVisibility is used only to decide whether a tag column exists.
-            # If the column exists (visible in any testcase), then show the tag
-            # value for every testcase that has it.
+            # Column exists only for tags visible in any testcase.
+            # For each testcase that has the tag, display Tags(tag).Value.
             if { $HasTags && [dict exists $TestCaseTags $TagName] } {
-              set TagValue [dict get $TestCaseTags $TagName]
+              set TagRec [dict get $TestCaseTags $TagName]
+              set TagValue ""
+              if {![catch {dict size $TagRec}] && [dict exists $TagRec Value]} {
+                set TagValue [dict get $TagRec Value]
+              }
               set TagDisplay [EscapeHtml [FormatScalarForHtml $TagValue]]
             } else {
               set TagDisplay "⸻"

--- a/ReportBuildDict2Html.tcl
+++ b/ReportBuildDict2Html.tcl
@@ -302,6 +302,7 @@ proc CreateTestCaseSummaries {TestDict} {
       puts $ResultsFile "      <table class=\"testcase-summary-table\">"
       puts $ResultsFile "        <thead>"
       puts $ResultsFile "          <tr><th rowspan=\"2\">Test Case</th>"
+      puts $ResultsFile "              <th rowspan=\"2\">Description</th>"
       puts $ResultsFile "              <th rowspan=\"2\">Status</th>"
       puts $ResultsFile "              <th colspan=\"3\">Checks</th>"
       puts $ResultsFile "              <th colspan=\"2\">Requirements</th>"
@@ -323,6 +324,12 @@ proc CreateTestCaseSummaries {TestDict} {
 
       foreach TestCase [dict get $TestSuite TestCases] {
         set TestName     [dict get $TestCase TestCaseName]
+        # Get test description if available
+        if { [dict exists $TestCase Description] } {
+          set TestDescription [dict get $TestCase Description]
+        } else {
+          set TestDescription ""
+        }
         if { [dict exists $TestCase Status] } { 
           set TestStatus    [dict get $TestCase Status]
           set TestResults [dict get $TestCase Results]
@@ -394,6 +401,7 @@ proc CreateTestCaseSummaries {TestDict} {
         }
         puts $ResultsFile "          <tr>"
         puts $ResultsFile "            <td><a href=\"${TestCaseHtmlFile}\">${TestCaseName}</a></td>"
+        puts $ResultsFile "            <td>${TestDescription}</td>"
         puts $ResultsFile "            <td ${StatusClass}>$TestStatus</td>"
         if { $TestReport eq "REPORT" } {
           puts $ResultsFile "            <td ${PassedClass}>[dict get $TestResults AffirmCount]</td>"
@@ -426,7 +434,7 @@ proc CreateTestCaseSummaries {TestDict} {
           }
           puts $ResultsFile "            <td>$TestCaseElapsedTime</td>"
         } else {
-          puts $ResultsFile "            <td style=\"text-align: left\" colspan=\"8\"> &emsp; $Reason</td>"
+          puts $ResultsFile "            <td style=\"text-align: left\" colspan=\"9\"> &emsp; $Reason</td>"
         }
         puts $ResultsFile "          </tr>"
       }

--- a/ReportBuildDict2Html.tcl
+++ b/ReportBuildDict2Html.tcl
@@ -233,6 +233,7 @@ proc CreateTestSuiteSummary  {} {
     puts $ResultsFile "              <th rowspan=\"2\">Requirements<br>passed / goal</th>"
     puts $ResultsFile "              <th rowspan=\"2\">Disabled<br>Alerts</th>"
     puts $ResultsFile "              <th rowspan=\"2\">Elapsed<br>Time</th>"
+    puts $ResultsFile "              <th rowspan=\"2\" style=\"width: 50%; text-align: center;\">Brief</th>"
     puts $ResultsFile "          </tr>"
     puts $ResultsFile "          <tr>"
     puts $ResultsFile "              <th>PASSED </th>"
@@ -245,6 +246,14 @@ proc CreateTestSuiteSummary  {} {
     foreach TestSuite $TestSuiteSummaryArrayOfDictionaries {
       set SuiteName [dict get $TestSuite Name]
       set SuiteStatus  [dict get $TestSuite Status]
+      if { [dict exists $TestSuite Brief] } {
+        set SuiteBrief [dict get $TestSuite Brief]
+      } elseif { [dict exists $TestSuite Description] } {
+        # Backward compatibility: use first line of Description
+        set SuiteBrief [lindex [split [dict get $TestSuite Description] "\n"] 0]
+      } else {
+        set SuiteBrief ""
+      }
 
       set PassedClass  "" 
       set FailedClass  "" 
@@ -279,6 +288,11 @@ proc CreateTestSuiteSummary  {} {
       }
       puts $ResultsFile "          <td>[dict get $TestSuite DisabledAlerts]</td>"
       puts $ResultsFile "          <td>[dict get $TestSuite ElapsedTime]</td>"
+      puts $ResultsFile "          <td style=\"text-align: left;\">"
+      if {${SuiteBrief} ne ""} {
+        puts $ResultsFile "            [EscapeHtml $SuiteBrief]"
+      }
+      puts $ResultsFile "          </td>"
       puts $ResultsFile "        </tr>"
     }
     puts $ResultsFile "        </tbody>"
@@ -297,20 +311,46 @@ proc CreateTestCaseSummaries {TestDict} {
   if { [dict exists $TestDict TestSuites] } {
     foreach TestSuite [dict get $TestDict TestSuites] {
       set SuiteName [dict get $TestSuite Name]
+
+      # Collect a stable list of generic names used by any test case in this suite.
+      # These become the subcolumns under the "Generics" column group.
+      set SuiteGenericNames {}
+      foreach TcForGenerics [dict get $TestSuite TestCases] {
+        if { [dict exists $TcForGenerics Generics] } {
+          set GenDict [dict get $TcForGenerics Generics]
+          if {![catch {dict size $GenDict}]} {
+            foreach GenName [dict keys $GenDict] {
+              if {[lsearch -exact $SuiteGenericNames $GenName] < 0} {
+                lappend SuiteGenericNames $GenName
+              }
+            }
+          }
+        }
+      }
+      set SuiteGenericCount [llength $SuiteGenericNames]
+
       puts $ResultsFile "  <div class=\"testcase\">"
       puts $ResultsFile "    <details open><summary id=\"$SuiteName\">$SuiteName Test Case Summary</summary>"
       puts $ResultsFile "      <table class=\"testcase-summary-table\">"
       puts $ResultsFile "        <thead>"
       puts $ResultsFile "          <tr><th rowspan=\"2\">Test Case</th>"
-      puts $ResultsFile "              <th rowspan=\"2\">Description</th>"
+      if { $SuiteGenericCount > 0 } {
+        puts $ResultsFile "              <th colspan=\"$SuiteGenericCount\">Generics</th>"
+      }
       puts $ResultsFile "              <th rowspan=\"2\">Status</th>"
       puts $ResultsFile "              <th colspan=\"3\">Checks</th>"
       puts $ResultsFile "              <th colspan=\"2\">Requirements</th>"
       puts $ResultsFile "              <th rowspan=\"2\">Functional<br>Coverage</th>"
       puts $ResultsFile "              <th rowspan=\"2\">Disabled<br>Alerts</th>"
       puts $ResultsFile "              <th rowspan=\"2\">Elapsed<br>Time</th>"
+      puts $ResultsFile "              <th rowspan=\"2\" style=\"width: 50%; text-align: center;\">Brief</th>"
       puts $ResultsFile "          </tr>"
       puts $ResultsFile "          <tr>"
+      if { $SuiteGenericCount > 0 } {
+        foreach GenName $SuiteGenericNames {
+          puts $ResultsFile "              <th>$GenName</th>"
+        }
+      }
       puts $ResultsFile "              <th>Total</th>"
       puts $ResultsFile "              <th>Passed</th>"
       puts $ResultsFile "              <th>Failed</th>"
@@ -324,11 +364,14 @@ proc CreateTestCaseSummaries {TestDict} {
 
       foreach TestCase [dict get $TestSuite TestCases] {
         set TestName     [dict get $TestCase TestCaseName]
-        # Get test description if available
-        if { [dict exists $TestCase Description] } {
-          set TestDescription [dict get $TestCase Description]
+        # Get test brief if available
+        if { [dict exists $TestCase Brief] } {
+          set TestBrief [dict get $TestCase Brief]
+        } elseif { [dict exists $TestCase Description] } {
+          # Backward compatibility: use first line of Description
+          set TestBrief [lindex [split [dict get $TestCase Description] "\n"] 0]
         } else {
-          set TestDescription ""
+          set TestBrief ""
         }
         if { [dict exists $TestCase Status] } { 
           set TestStatus    [dict get $TestCase Status]
@@ -382,13 +425,14 @@ proc CreateTestCaseSummaries {TestDict} {
         }
         set TestCaseHtmlFile [file join ${TestSuiteReportsDirectory} ${TestFileName}.html]
         set TestCaseName $TestName
-        if { [dict exists $TestCase Generics] } { 
+        # Backward compatibility: if there are no generic columns, append generic values to the Test Case name.
+        if { ($SuiteGenericCount == 0) && [dict exists $TestCase Generics] } {
           set TestCaseGenerics [dict get $TestCase Generics]
-          if {${TestCaseGenerics} ne ""} {
-            set GenericValueList [dict values $TestCaseGenerics] 
+          if {![catch {dict size $TestCaseGenerics}] && ([dict size $TestCaseGenerics] > 0)} {
+            set GenericValueList [dict values $TestCaseGenerics]
             set i 0
             set ListLen [llength ${GenericValueList}]
-            append TestCaseName " (" 
+            append TestCaseName " ("
             foreach GenericValue $GenericValueList {
               incr i
               if {$i != $ListLen} {
@@ -401,7 +445,29 @@ proc CreateTestCaseSummaries {TestDict} {
         }
         puts $ResultsFile "          <tr>"
         puts $ResultsFile "            <td><a href=\"${TestCaseHtmlFile}\">${TestCaseName}</a></td>"
-        puts $ResultsFile "            <td>${TestDescription}</td>"
+
+        # Generics are the second column group (after Test Case name).
+        if { $SuiteGenericCount > 0 } {
+          if { [dict exists $TestCase Generics] } {
+            set TestCaseGenerics [dict get $TestCase Generics]
+          } else {
+            set TestCaseGenerics ""
+          }
+          set HasGenerics 0
+          if {![catch {dict size $TestCaseGenerics}] && ([dict size $TestCaseGenerics] > 0)} {
+            set HasGenerics 1
+          }
+          foreach GenName $SuiteGenericNames {
+            if { $HasGenerics && [dict exists $TestCaseGenerics $GenName] } {
+              set GenValue [dict get $TestCaseGenerics $GenName]
+            } else {
+              set GenValue "⸻"
+            }
+            set GenDisplayValue [FormatGenericValueForHtml $GenName $GenValue $TestFileName]
+            puts $ResultsFile "            <td>$GenDisplayValue</td>"
+          }
+        }
+
         puts $ResultsFile "            <td ${StatusClass}>$TestStatus</td>"
         if { $TestReport eq "REPORT" } {
           puts $ResultsFile "            <td ${PassedClass}>[dict get $TestResults AffirmCount]</td>"
@@ -433,8 +499,15 @@ proc CreateTestCaseSummaries {TestDict} {
             set TestCaseElapsedTime missing
           }
           puts $ResultsFile "            <td>$TestCaseElapsedTime</td>"
+          puts $ResultsFile "            <td style=\"text-align: left;\">"
+          if {${TestBrief} ne ""} {
+            puts $ResultsFile "              [EscapeHtml $TestBrief]"
+          }
+          puts $ResultsFile "            </td>"
         } else {
-          puts $ResultsFile "            <td style=\"text-align: left\" colspan=\"9\"> &emsp; $Reason</td>"
+          # Remaining columns after Test Case + (optional Generics) + Status
+          set RemainingColumns 9
+          puts $ResultsFile "            <td style=\"text-align: left\" colspan=\"$RemainingColumns\"> &emsp; $Reason</td>"
         }
         puts $ResultsFile "          </tr>"
       }

--- a/ReportBuildDict2Html.tcl
+++ b/ReportBuildDict2Html.tcl
@@ -312,22 +312,123 @@ proc CreateTestCaseSummaries {TestDict} {
     foreach TestSuite [dict get $TestDict TestSuites] {
       set SuiteName [dict get $TestSuite Name]
 
+      # Configuration hooks (set via OSVVM-Scripts/OsvvmScriptsCore.tcl APIs)
+      set ConfigShowGenerics 1
+      if {[info exists ::osvvm::TestCaseSummaryShowGenerics]} {
+        set ConfigShowGenerics $::osvvm::TestCaseSummaryShowGenerics
+      }
+      set ConfigGenericWhitelist {}
+      if {[info exists ::osvvm::TestCaseSummaryGenericNames]} {
+        set ConfigGenericWhitelist $::osvvm::TestCaseSummaryGenericNames
+      }
+
+      # Default: show tags in the Test Case Summary table
+      set ConfigShowTags 1
+      if {[info exists ::osvvm::TestCaseSummaryShowTags]} {
+        set ConfigShowTags $::osvvm::TestCaseSummaryShowTags
+      }
+      set ConfigTagWhitelist {}
+      if {[info exists ::osvvm::TestCaseSummaryTagNames]} {
+        set ConfigTagWhitelist $::osvvm::TestCaseSummaryTagNames
+      }
+
       # Collect a stable list of generic names used by any test case in this suite.
       # These become the subcolumns under the "Generics" column group.
-      set SuiteGenericNames {}
+      set SuiteGenericNamesAll {}
       foreach TcForGenerics [dict get $TestSuite TestCases] {
         if { [dict exists $TcForGenerics Generics] } {
           set GenDict [dict get $TcForGenerics Generics]
           if {![catch {dict size $GenDict}]} {
             foreach GenName [dict keys $GenDict] {
-              if {[lsearch -exact $SuiteGenericNames $GenName] < 0} {
-                lappend SuiteGenericNames $GenName
+              if {[lsearch -exact $SuiteGenericNamesAll $GenName] < 0} {
+                lappend SuiteGenericNamesAll $GenName
               }
             }
           }
         }
       }
+
+      # Apply generics configuration
+      if {!$ConfigShowGenerics} {
+        set SuiteGenericNames {}
+      } elseif {[llength $ConfigGenericWhitelist] == 0} {
+        set SuiteGenericNames $SuiteGenericNamesAll
+      } else {
+        set SuiteGenericNames {}
+        foreach GenName $ConfigGenericWhitelist {
+          if {[lsearch -exact $SuiteGenericNamesAll $GenName] >= 0} {
+            lappend SuiteGenericNames $GenName
+          }
+        }
+      }
       set SuiteGenericCount [llength $SuiteGenericNames]
+      set SuiteGenericCountAll [llength $SuiteGenericNamesAll]
+
+      # Collect tag names (stable order) and determine visibility across all testcases.
+      # A tag column is included if the tag is visible in ANY testcase.
+      set SuiteTagNamesAll {}
+      set SuiteTagVisibleAny [dict create]
+      if {$ConfigShowTags} {
+        foreach TcForTags [dict get $TestSuite TestCases] {
+          if { [dict exists $TcForTags Tags] } {
+            set TagsDict [dict get $TcForTags Tags]
+            if {![catch {dict size $TagsDict}]} {
+              foreach TagName [dict keys $TagsDict] {
+                # Maintain stable ordering based on first occurrence in the suite.
+                if {[lsearch -exact $SuiteTagNamesAll $TagName] < 0} {
+                  lappend SuiteTagNamesAll $TagName
+                }
+
+                # Per-tag visibility for this testcase (default visible).
+                set IsVisible 1
+                if {[dict exists $TcForTags TagVisibility]} {
+                  set VisDict [dict get $TcForTags TagVisibility]
+                  if {![catch {dict size $VisDict}]} {
+                    if {[dict exists $VisDict $TagName]} {
+                      set VisVal [dict get $VisDict $TagName]
+                      if {$VisVal eq 0 || $VisVal eq "0" || [string equal -nocase $VisVal "false"]} {
+                        set IsVisible 0
+                      }
+                    }
+                  }
+                }
+
+                # Track if visible in any testcase.
+                if {$IsVisible} {
+                  dict set SuiteTagVisibleAny $TagName 1
+                } elseif {![dict exists $SuiteTagVisibleAny $TagName]} {
+                  dict set SuiteTagVisibleAny $TagName 0
+                }
+              }
+            }
+          }
+        }
+      }
+
+      # Filter final set of tag columns: include only tags visible in ANY testcase.
+      if {!$ConfigShowTags} {
+        set SuiteTagNames {}
+      } else {
+        # Candidate tags by order (either auto-discovered or whitelist)
+        if {[llength $ConfigTagWhitelist] == 0} {
+          set CandidateTagNames $SuiteTagNamesAll
+        } else {
+          set CandidateTagNames $ConfigTagWhitelist
+        }
+
+        set SuiteTagNames {}
+        foreach TagName $CandidateTagNames {
+          # If a whitelist asks for a tag not present in the suite, skip it.
+          if {[lsearch -exact $SuiteTagNamesAll $TagName] < 0} {
+            continue
+          }
+          # Only include if visible in any testcase.
+          if {[dict exists $SuiteTagVisibleAny $TagName] && [dict get $SuiteTagVisibleAny $TagName]} {
+            lappend SuiteTagNames $TagName
+          }
+        }
+      }
+      set SuiteTagCount [llength $SuiteTagNames]
 
       puts $ResultsFile "  <div class=\"testcase\">"
       puts $ResultsFile "    <details open><summary id=\"$SuiteName\">$SuiteName Test Case Summary</summary>"
@@ -336,6 +437,9 @@ proc CreateTestCaseSummaries {TestDict} {
       puts $ResultsFile "          <tr><th rowspan=\"2\">Test Case</th>"
       if { $SuiteGenericCount > 0 } {
         puts $ResultsFile "              <th colspan=\"$SuiteGenericCount\">Generics</th>"
+      }
+      if { $SuiteTagCount > 0 } {
+        puts $ResultsFile "              <th colspan=\"$SuiteTagCount\">Tags</th>"
       }
       puts $ResultsFile "              <th rowspan=\"2\">Status</th>"
       puts $ResultsFile "              <th colspan=\"3\">Checks</th>"
@@ -348,7 +452,12 @@ proc CreateTestCaseSummaries {TestDict} {
       puts $ResultsFile "          <tr>"
       if { $SuiteGenericCount > 0 } {
         foreach GenName $SuiteGenericNames {
-          puts $ResultsFile "              <th>$GenName</th>"
+          puts $ResultsFile "              <th style=\"text-align: center;\">$GenName</th>"
+        }
+      }
+      if { $SuiteTagCount > 0 } {
+        foreach TagName $SuiteTagNames {
+          puts $ResultsFile "              <th style=\"text-align: center;\">$TagName</th>"
         }
       }
       puts $ResultsFile "              <th>Total</th>"
@@ -426,7 +535,8 @@ proc CreateTestCaseSummaries {TestDict} {
         set TestCaseHtmlFile [file join ${TestSuiteReportsDirectory} ${TestFileName}.html]
         set TestCaseName $TestName
         # Backward compatibility: if there are no generic columns, append generic values to the Test Case name.
-        if { ($SuiteGenericCount == 0) && [dict exists $TestCase Generics] } {
+        # Do this only when the suite truly has no generics (not when generics are hidden via config).
+        if { ($SuiteGenericCountAll == 0) && [dict exists $TestCase Generics] } {
           set TestCaseGenerics [dict get $TestCase Generics]
           if {![catch {dict size $TestCaseGenerics}] && ([dict size $TestCaseGenerics] > 0)} {
             set GenericValueList [dict values $TestCaseGenerics]
@@ -464,7 +574,32 @@ proc CreateTestCaseSummaries {TestDict} {
               set GenValue "⸻"
             }
             set GenDisplayValue [FormatGenericValueForHtml $GenName $GenValue $TestFileName]
-            puts $ResultsFile "            <td>$GenDisplayValue</td>"
+            puts $ResultsFile "            <td style=\"text-align: center;\">$GenDisplayValue</td>"
+          }
+        }
+
+        # Optional Tags column group (after Generics, before Status).
+        if { $SuiteTagCount > 0 } {
+          if { [dict exists $TestCase Tags] } {
+            set TestCaseTags [dict get $TestCase Tags]
+          } else {
+            set TestCaseTags ""
+          }
+          set HasTags 0
+          if {![catch {dict size $TestCaseTags}] && ([dict size $TestCaseTags] > 0)} {
+            set HasTags 1
+          }
+          foreach TagName $SuiteTagNames {
+            # TagVisibility is used only to decide whether a tag column exists.
+            # If the column exists (visible in any testcase), then show the tag
+            # value for every testcase that has it.
+            if { $HasTags && [dict exists $TestCaseTags $TagName] } {
+              set TagValue [dict get $TestCaseTags $TagName]
+              set TagDisplay [EscapeHtml [FormatScalarForHtml $TagValue]]
+            } else {
+              set TagDisplay "⸻"
+            }
+            puts $ResultsFile "            <td style=\"text-align: left;\">$TagDisplay</td>"
           }
         }
 

--- a/ReportBuildDict2Junit.tcl
+++ b/ReportBuildDict2Junit.tcl
@@ -222,10 +222,23 @@ proc CreateJunitTestSuiteSummaries {TestDict TestSuiteSummary } {
       if { [dict exists $TestCase Tags] } {
         set TagsDict [dict get $TestCase Tags]
         if {![catch {dict size $TagsDict}] && ([dict size $TagsDict] > 0)} {
+          # TagTypes is required when Tags are present.
+          if {![dict exists $TestCase TagTypes]} {
+            error "JUnit: TestCase has Tags but no TagTypes. Regenerate YAML with TagTypes enabled." 
+          }
+          set TagTypesDict [dict get $TestCase TagTypes]
           foreach {TagName TagValue} $TagsDict {
             set TagNameEsc [EscapeXmlAttr $TagName]
             set TagValueEsc [EscapeXmlAttr $TagValue]
             lappend PropertyLines "  <property name=\"${TagNameEsc}\" value=\"${TagValueEsc}\" /> "
+
+            if {![dict exists $TagTypesDict $TagName]} {
+              error "JUnit: Missing TagTypes entry for tag '$TagName'." 
+            }
+            set TagTypeToken [dict get $TagTypesDict $TagName]
+            set TagTypeNameEsc [EscapeXmlAttr "tagtype:${TagName}"]
+            set TagTypeValueEsc [EscapeXmlAttr $TagTypeToken]
+            lappend PropertyLines "  <property name=\"${TagTypeNameEsc}\" value=\"${TagTypeValueEsc}\" /> "
           }
         }
       }

--- a/ReportBuildDict2Junit.tcl
+++ b/ReportBuildDict2Junit.tcl
@@ -48,6 +48,16 @@
 package require yaml
 
 # -------------------------------------------------
+# EscapeXmlAttr
+#
+# Escape content for safe use inside XML attribute values.
+proc EscapeXmlAttr {Text} {
+  set Escaped $Text
+  set Escaped [string map [list "&" "&amp;" "<" "&lt;" ">" "&gt;" "\"" "&quot;" "'" "&apos;"] $Escaped]
+  return $Escaped
+}
+
+# -------------------------------------------------
 # ReportBuildDict2Junit
 #
 proc ReportBuildDict2Junit {} {
@@ -180,31 +190,62 @@ proc CreateJunitTestSuiteSummaries {TestDict TestSuiteSummary } {
         set ResolvedTestName $TestName
       }
 
+      # Collect testcase properties (generics + brief + tags)
+      set PropertyLines {}
+      if { [dict exists $TestCase Generics] } {
+        set TestCaseGenerics [dict get $TestCase Generics]
+        if {${TestCaseGenerics} ne ""} {
+          foreach {GenericName GenericValue} $TestCaseGenerics {
+            set GName [EscapeXmlAttr $GenericName]
+            set GValue [EscapeXmlAttr "${GenericName}=${GenericValue}"]
+            lappend PropertyLines "  <property name=\"generic\" value=\"${GValue}\" /> "
+          }
+        }
+      }
+
+      if { [dict exists $TestCase Brief] } {
+        set BriefValue [dict get $TestCase Brief]
+        if {$BriefValue ne ""} {
+          set BriefEsc [EscapeXmlAttr $BriefValue]
+          lappend PropertyLines "  <property name=\"brief\" value=\"${BriefEsc}\" /> "
+        }
+      }
+
+      if { [dict exists $TestCase Tags] } {
+        set TagsDict [dict get $TestCase Tags]
+        if {![catch {dict size $TagsDict}] && ([dict size $TagsDict] > 0)} {
+          foreach {TagName TagValue} $TagsDict {
+            set TagNameEsc [EscapeXmlAttr $TagName]
+            set TagValueEsc [EscapeXmlAttr $TagValue]
+            lappend PropertyLines "  <property name=\"${TagNameEsc}\" value=\"${TagValueEsc}\" /> "
+          }
+        }
+      }
+
       puts $ResultsFile "<testcase "
-      puts $ResultsFile "   name=\"$ResolvedTestName\""
+      puts $ResultsFile "   name=\"[EscapeXmlAttr $ResolvedTestName]\""
 #      puts $ResultsFile "   classname=\"$VhdlName\""
-      puts $ResultsFile "   classname=\"$TestSuiteName\""
+      puts $ResultsFile "   classname=\"[EscapeXmlAttr $TestSuiteName]\""
       puts $ResultsFile "   assertions=\"$AffirmCount\""
       puts $ResultsFile "   time=\"$ElapsedTime\""
       puts $ResultsFile ">"
-      
-      if { [dict exists $TestCase Generics] } { 
-        set TestCaseGenerics [dict get $TestCase Generics]
-        if {${TestCaseGenerics} ne ""} {
-          puts $ResultsFile "<properties> "
-          foreach {GenericName GenericValue} $TestCaseGenerics {
-            puts $ResultsFile "  <property name=\"generic\" value=\"${GenericName}=${GenericValue}\" /> "
-          }
-          puts $ResultsFile "</properties> "
+
+      if {[llength $PropertyLines] > 0} {
+        puts $ResultsFile "<properties> "
+        foreach Line $PropertyLines {
+          puts $ResultsFile $Line
         }
+        puts $ResultsFile "</properties> "
       }
       
       if { $TestStatus eq "FAILED" } {
-        puts $ResultsFile "<failure message=\"$Reason\">$Reason</failure>"
+        set ReasonEsc [EscapeXmlAttr $Reason]
+        puts $ResultsFile "<failure message=\"$ReasonEsc\">$ReasonEsc</failure>"
       
       } elseif { $TestStatus eq "SKIPPED" } {
         set Reason [dict get $TestResults Reason]
-        puts $ResultsFile "<skipped message=\"$Reason\">$Reason</skipped>"
+        set ReasonEsc [EscapeXmlAttr $Reason]
+        puts $ResultsFile "<skipped message=\"$ReasonEsc\">$ReasonEsc</skipped>"
       }
       puts $ResultsFile "</testcase>"
     }

--- a/ReportBuildDict2Junit.tcl
+++ b/ReportBuildDict2Junit.tcl
@@ -211,6 +211,14 @@ proc CreateJunitTestSuiteSummaries {TestDict TestSuiteSummary } {
         }
       }
 
+      if { [dict exists $TestCase Title] } {
+        set TitleValue [dict get $TestCase Title]
+        if {$TitleValue ne ""} {
+          set TitleEsc [EscapeXmlAttr $TitleValue]
+          lappend PropertyLines "  <property name=\"title\" value=\"${TitleEsc}\" /> "
+        }
+      }
+
       if { [dict exists $TestCase Tags] } {
         set TagsDict [dict get $TestCase Tags]
         if {![catch {dict size $TagsDict}] && ([dict size $TagsDict] > 0)} {

--- a/ReportBuildDict2Junit.tcl
+++ b/ReportBuildDict2Junit.tcl
@@ -222,20 +222,24 @@ proc CreateJunitTestSuiteSummaries {TestDict TestSuiteSummary } {
       if { [dict exists $TestCase Tags] } {
         set TagsDict [dict get $TestCase Tags]
         if {![catch {dict size $TagsDict}] && ([dict size $TagsDict] > 0)} {
-          # TagTypes is required when Tags are present.
-          if {![dict exists $TestCase TagTypes]} {
-            error "JUnit: TestCase has Tags but no TagTypes. Regenerate YAML with TagTypes enabled." 
-          }
-          set TagTypesDict [dict get $TestCase TagTypes]
-          foreach {TagName TagValue} $TagsDict {
+          foreach TagName [dict keys $TagsDict] {
+            set TagRec [dict get $TagsDict $TagName]
+
+            set TagValue ""
+            if {[dict exists $TagRec Value]} {
+              set TagValue [dict get $TagRec Value]
+            }
+
+            # Type is required when Tags are present (no fallback/inference).
+            if {![dict exists $TagRec Type]} {
+              error "JUnit: Missing Type for tag '$TagName'." 
+            }
+            set TagTypeToken [dict get $TagRec Type]
+
             set TagNameEsc [EscapeXmlAttr $TagName]
             set TagValueEsc [EscapeXmlAttr $TagValue]
             lappend PropertyLines "  <property name=\"${TagNameEsc}\" value=\"${TagValueEsc}\" /> "
 
-            if {![dict exists $TagTypesDict $TagName]} {
-              error "JUnit: Missing TagTypes entry for tag '$TagName'." 
-            }
-            set TagTypeToken [dict get $TagTypesDict $TagName]
             set TagTypeNameEsc [EscapeXmlAttr "tagtype:${TagName}"]
             set TagTypeValueEsc [EscapeXmlAttr $TagTypeToken]
             lappend PropertyLines "  <property name=\"${TagTypeNameEsc}\" value=\"${TagTypeValueEsc}\" /> "

--- a/ReportBuildYaml2Dict.tcl
+++ b/ReportBuildYaml2Dict.tcl
@@ -211,6 +211,19 @@ proc ElaborateTestSuites {TestDict} {
         set SuiteStatus "FAILED"
         set BuildStatus "FAILED"
       }
+      if {[dict exists $TestSuite Description]} {
+        set SuiteDescription [dict get $TestSuite Description]
+      } else {
+        set SuiteDescription ""
+      }
+      if {[dict exists $TestSuite Brief]} {
+        set SuiteBrief [dict get $TestSuite Brief]
+      } elseif {$SuiteDescription ne ""} {
+        # Backward compatibility: use first line of Description
+        set SuiteBrief [lindex [split $SuiteDescription "\n"] 0]
+      } else {
+        set SuiteBrief ""
+      }
       set SuiteDict [dict create Name       $SuiteName]
       dict append SuiteDict Status          $SuiteStatus
       dict append SuiteDict PASSED          $SuitePassed
@@ -220,6 +233,8 @@ proc ElaborateTestSuites {TestDict} {
       dict append SuiteDict ReqGoal         $SuiteReqGoal
       dict append SuiteDict DisabledAlerts  $SuiteDisabledAlerts
       dict append SuiteDict ElapsedTime     $SuiteElapsedTime
+      dict set    SuiteDict Brief           $SuiteBrief
+      dict set    SuiteDict Description     $SuiteDescription
       lappend TestSuiteSummaryArrayOfDictionaries $SuiteDict
     }
   }

--- a/ReportBuildYaml2Dict.tcl
+++ b/ReportBuildYaml2Dict.tcl
@@ -216,11 +216,13 @@ proc ElaborateTestSuites {TestDict} {
       } else {
         set SuiteDescription ""
       }
+      if {[dict exists $TestSuite Title]} {
+        set SuiteTitle [dict get $TestSuite Title]
+      } else {
+        set SuiteTitle ""
+      }
       if {[dict exists $TestSuite Brief]} {
         set SuiteBrief [dict get $TestSuite Brief]
-      } elseif {$SuiteDescription ne ""} {
-        # Backward compatibility: use first line of Description
-        set SuiteBrief [lindex [split $SuiteDescription "\n"] 0]
       } else {
         set SuiteBrief ""
       }
@@ -233,6 +235,7 @@ proc ElaborateTestSuites {TestDict} {
       dict append SuiteDict ReqGoal         $SuiteReqGoal
       dict append SuiteDict DisabledAlerts  $SuiteDisabledAlerts
       dict append SuiteDict ElapsedTime     $SuiteElapsedTime
+      dict set    SuiteDict Title           $SuiteTitle
       dict set    SuiteDict Brief           $SuiteBrief
       dict set    SuiteDict Description     $SuiteDescription
       lappend TestSuiteSummaryArrayOfDictionaries $SuiteDict

--- a/ReportCov2Html.tcl
+++ b/ReportCov2Html.tcl
@@ -64,9 +64,18 @@ proc Cov2Html {TestCaseName TestSuiteName CovYamlFile} {
 proc LocalCov2Html {TestCaseName TestSuiteName CovYamlFile} {
   variable ResultsFile
 
+  # Prefer Title (if set) for visible headings; fall back to testcase name.
+  set DisplayName $TestCaseName
+  if {[info exists ::osvvm::Report2TestTitle]} {
+    set CandidateTitle [string trim $::osvvm::Report2TestTitle]
+    if {$CandidateTitle ne ""} {
+      set DisplayName $CandidateTitle
+    }
+  }
+
   puts $ResultsFile "  <hr />"
   puts $ResultsFile "  <div class=\"FunctionalCoverage\">"
-  puts $ResultsFile "    <h2 id=\"FunctionalCoverage\">$TestCaseName Coverage Report</h2>"
+  puts $ResultsFile "    <h2 id=\"FunctionalCoverage\">$DisplayName Coverage Report</h2>"
 
   set TestDict [::yaml::yaml2dict -file ${CovYamlFile}]
   set VersionNum    [dict get $TestDict Version]

--- a/ReportScoreboard2Html.tcl
+++ b/ReportScoreboard2Html.tcl
@@ -59,10 +59,19 @@ proc Scoreboard2Html {TestCaseName TestSuiteName SbYamlFile SbName} {
 
 proc LocalScoreboard2Html {TestCaseName TestSuiteName SbYamlFile SbName} {
   variable ResultsFile
+
+  # Prefer Title (if set) for visible headings; fall back to testcase name.
+  set DisplayName $TestCaseName
+  if {[info exists ::osvvm::Report2TestTitle]} {
+    set CandidateTitle [string trim $::osvvm::Report2TestTitle]
+    if {$CandidateTitle ne ""} {
+      set DisplayName $CandidateTitle
+    }
+  }
   
   puts $ResultsFile "  <hr />"
   puts $ResultsFile "  <div class=\"ScoreboardSummary\">"
-  puts $ResultsFile "    <h2 id=\"${SbName}\">$TestCaseName Scoreboard Report for ${SbName}</h2>"
+  puts $ResultsFile "    <h2 id=\"${SbName}\">$DisplayName Scoreboard Report for ${SbName}</h2>"
   puts $ResultsFile "    <div class=\"${SbName}\">"
   puts $ResultsFile "      <table class=\"ScoreboardSummary\">"
 

--- a/ReportSimulate2Html.tcl
+++ b/ReportSimulate2Html.tcl
@@ -62,6 +62,11 @@ proc Simulate2Html {SettingsFileWithPath} {
   
     
   GetTestCaseSettings $SettingsFileWithPath 
+
+  # Align local script variables with ::osvvm settings parsed from YAML
+  # (avoids stale values between testcases)
+  set Report2AlertYamlFile $::osvvm::Report2AlertYamlFile
+  set Report2CovYamlFile   $::osvvm::Report2CovYamlFile
   
   set TestCaseFileName $::osvvm::Report2TestCaseFileName
   set TestCaseName     $::osvvm::Report2TestCaseName  
@@ -156,26 +161,6 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
   puts $ResultsFile "        </thead>"
   puts $ResultsFile "        <tbody>"
 
-  # Print test description if available
-  if {[info exists ::osvvm::Report2TestDescription] && $::osvvm::Report2TestDescription ne ""} {
-    puts $ResultsFile "          <tr><td><strong>Description:</strong> $::osvvm::Report2TestDescription</td></tr>"
-  }
-
-  # Print test tags if available
-  if {[info exists ::osvvm::Report2TestTags] && $::osvvm::Report2TestTags ne ""} {
-    puts $ResultsFile "          <tr><td><strong>Test Configuration:</strong></td></tr>"
-    foreach {TagName TagValue} $::osvvm::Report2TestTags {
-      puts $ResultsFile "          <tr><td>&emsp;$TagName: $TagValue</td></tr>"
-    }
-  }
-
-  # Print the Generics
-  if {${GenericDict} ne ""} {
-    foreach {GenericName GenericValue} $GenericDict {
-      puts $ResultsFile "          <tr><td>Generic: $GenericName = $GenericValue</td></tr>"
-    }
-  }
-
   if {[file exists ${::osvvm::Report2AlertYamlFile}]} {
     puts $ResultsFile "          <tr><td><a href=\"#AlertSummary\">Alert Report</a></td></tr>"
   }
@@ -223,6 +208,48 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
   LinkLogoFile $ResultsFile $ReportsPrefix
 
   puts $ResultsFile "  </div>"
+
+  # Render Description / Tags / Generics as independent sections
+  # (user-requested: Description not in a table; Tags + Generics in tables)
+  if {[info exists ::osvvm::Report2TestDescription] && $::osvvm::Report2TestDescription ne ""} {
+    puts $ResultsFile "  <div class=\"TestDescription\">"
+    puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Description</summary>"
+    WriteMarkdownSubsetAsHtml $ResultsFile $::osvvm::Report2TestDescription "      "
+    puts $ResultsFile "    </details>"
+    puts $ResultsFile "  </div>"
+  }
+
+  if {[info exists ::osvvm::Report2TestTags] && $::osvvm::Report2TestTags ne ""} {
+    puts $ResultsFile "  <div class=\"TestTags\">"
+    puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Tags</summary>"
+    puts $ResultsFile "      <table class=\"AlertSettings\">"
+    puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th></tr></thead>"
+    puts $ResultsFile "        <tbody>"
+    foreach {TagName TagValue} $::osvvm::Report2TestTags {
+      set TagDisplayValue [FormatScalarForHtml $TagValue]
+      puts $ResultsFile "          <tr><td>$TagName</td><td>$TagDisplayValue</td></tr>"
+    }
+    puts $ResultsFile "        </tbody>"
+    puts $ResultsFile "      </table>"
+    puts $ResultsFile "    </details>"
+    puts $ResultsFile "  </div>"
+  }
+
+  if {${GenericDict} ne ""} {
+    puts $ResultsFile "  <div class=\"TestGenerics\">"
+    puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Generics</summary>"
+    puts $ResultsFile "      <table class=\"AlertSettings\">"
+    puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th></tr></thead>"
+    puts $ResultsFile "        <tbody>"
+    foreach {GenericName GenericValue} $GenericDict {
+      set GenericDisplayValue [FormatGenericValueForHtml $GenericName $GenericValue $::osvvm::Report2GenericNames]
+      puts $ResultsFile "          <tr><td>$GenericName</td><td>$GenericDisplayValue</td></tr>"
+    }
+    puts $ResultsFile "        </tbody>"
+    puts $ResultsFile "      </table>"
+    puts $ResultsFile "    </details>"
+    puts $ResultsFile "  </div>"
+  }
 }
 
 proc FinalizeSimulationReportFile {} {

--- a/ReportSimulate2Html.tcl
+++ b/ReportSimulate2Html.tcl
@@ -69,7 +69,20 @@ proc Simulate2Html {SettingsFileWithPath} {
   set BuildName        $::osvvm::Report2BuildName     
   set GenericDict      $::osvvm::Report2GenericDict   
 
-  
+  # Initialize description and tags to empty
+  set ::osvvm::Report2TestDescription ""
+  set ::osvvm::Report2TestTags ""
+
+  # Read Description and Tags from Alert YAML file before creating summary table
+  if {[file exists ${Report2AlertYamlFile}]} {
+    set AlertDict [::yaml::yaml2dict -file ${Report2AlertYamlFile}]
+    if {[dict exists $AlertDict Description]} {
+      set ::osvvm::Report2TestDescription [dict get $AlertDict Description]
+    }
+    if {[dict exists $AlertDict Tags]} {
+      set ::osvvm::Report2TestTags [dict get $AlertDict Tags]
+    }
+  }
 
   CreateTestCaseSummaryTable ${TestCaseName} ${TestSuiteName} ${BuildName} ${GenericDict}
   
@@ -142,6 +155,19 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
   puts $ResultsFile "          <tr class=\"column-header\"><th>Available Reports</th></tr>"
   puts $ResultsFile "        </thead>"
   puts $ResultsFile "        <tbody>"
+
+  # Print test description if available
+  if {[info exists ::osvvm::Report2TestDescription] && $::osvvm::Report2TestDescription ne ""} {
+    puts $ResultsFile "          <tr><td><strong>Description:</strong> $::osvvm::Report2TestDescription</td></tr>"
+  }
+
+  # Print test tags if available
+  if {[info exists ::osvvm::Report2TestTags] && $::osvvm::Report2TestTags ne ""} {
+    puts $ResultsFile "          <tr><td><strong>Test Configuration:</strong></td></tr>"
+    foreach {TagName TagValue} $::osvvm::Report2TestTags {
+      puts $ResultsFile "          <tr><td>&emsp;$TagName: $TagValue</td></tr>"
+    }
+  }
 
   # Print the Generics
   if {${GenericDict} ne ""} {

--- a/ReportSimulate2Html.tcl
+++ b/ReportSimulate2Html.tcl
@@ -85,8 +85,6 @@ proc Simulate2Html {SettingsFileWithPath} {
   set ::osvvm::Report2TestDescription ""
   set ::osvvm::Report2TestBrief ""
   set ::osvvm::Report2TestTags ""
-  set ::osvvm::Report2TestTagSummaryVisibility ""
-  set ::osvvm::Report2TestTagTypes ""
   set ::osvvm::Report2TestStatus ""
   if {![info exists ::osvvm::Report2TestCaseSimulationTime]} {
     set ::osvvm::Report2TestCaseSimulationTime ""
@@ -181,12 +179,6 @@ proc Simulate2Html {SettingsFileWithPath} {
     }
     if {[dict exists $AlertDict Tags]} {
       set ::osvvm::Report2TestTags [dict get $AlertDict Tags]
-    }
-    if {[dict exists $AlertDict TagSummaryVisibility]} {
-      set ::osvvm::Report2TestTagSummaryVisibility [dict get $AlertDict TagSummaryVisibility]
-    }
-    if {[dict exists $AlertDict TagTypes]} {
-      set ::osvvm::Report2TestTagTypes [dict get $AlertDict TagTypes]
     }
   }
 
@@ -394,59 +386,52 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestDisplayName TestSuiteName
     puts $ResultsFile "  <div class=\"TestTags\">"
     puts $ResultsFile "    <details open><summary class=\"subtitle testcase-section-heading\"><span class=\"tc-name\">[EscapeHtml $TestDisplayName]</span><span class=\"tc-sep\"> — </span><span class=\"tc-suffix\">Tags</span></summary>"
     puts $ResultsFile "      <table class=\"AlertSettings\">"
-    set HasTagSummaryVisibility 0
-    if {[info exists ::osvvm::Report2TestTagSummaryVisibility] && $::osvvm::Report2TestTagSummaryVisibility ne ""} {
-      if {![catch {dict size $::osvvm::Report2TestTagSummaryVisibility}] && ([dict size $::osvvm::Report2TestTagSummaryVisibility] > 0)} {
-        set HasTagSummaryVisibility 1
-      }
-    }
-    if {$HasTagSummaryVisibility} {
-      puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th><th>Type</th><th>ShowInSummary</th></tr></thead>"
-    } else {
-      puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th><th>Type</th></tr></thead>"
-    }
+    puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th><th>Type</th><th>ShowInSummary</th></tr></thead>"
     puts $ResultsFile "        <tbody>"
-    foreach {TagName TagValue} $::osvvm::Report2TestTags {
+    foreach TagName [dict keys $::osvvm::Report2TestTags] {
+      set TagRec [dict get $::osvvm::Report2TestTags $TagName]
+
+      set TagValue ""
+      if {[dict exists $TagRec Value]} {
+        set TagValue [dict get $TagRec Value]
+      }
       set TagDisplayValue [FormatScalarForHtml $TagValue]
 
-      # Prefer explicit tag types from YAML when available.
+      # Explicit tag type from YAML (no inference/fallback)
       set TagType ""
-      if {[info exists ::osvvm::Report2TestTagTypes] && $::osvvm::Report2TestTagTypes ne ""} {
-        if {![catch {dict size $::osvvm::Report2TestTagTypes}] && [dict exists $::osvvm::Report2TestTagTypes $TagName]} {
-          set TagTypeToken [dict get $::osvvm::Report2TestTagTypes $TagName]
-          switch -nocase -- $TagTypeToken {
-            TAG_STRING    { set TagType "string" }
-            TAG_BOOL      { set TagType "boolean" }
-            TAG_INT       { set TagType "integer" }
-            TAG_REAL      { set TagType "real" }
-            TAG_TIME      { set TagType "time" }
-            TAG_STD_LOGIC { set TagType "std_logic" }
-            default       { set TagType "" }
-          }
+      if {[dict exists $TagRec Type]} {
+        set TagTypeToken [dict get $TagRec Type]
+        switch -nocase -- $TagTypeToken {
+          TAG_STRING    { set TagType "string" }
+          TAG_BOOL      { set TagType "boolean" }
+          TAG_INT       { set TagType "integer" }
+          TAG_REAL      { set TagType "real" }
+          TAG_TIME      { set TagType "time" }
+          TAG_STD_LOGIC { set TagType "std_logic" }
+          default       { set TagType "" }
         }
       }
 
-      # Backward compatible fallback for older YAML (no TagTypes)
       if {$TagType eq ""} {
-        if {$TagDisplayValue eq "True" || $TagDisplayValue eq "False"} {
-          set TagType "boolean"
-        } else {
-          set TagType [InferScalarTypeForHtml $TagValue]
-        }
+        set TagType "⸻"
       }
 
       set TagTypeClass [string tolower $TagType]
       regsub -all {[^a-z0-9_-]} $TagTypeClass "_" TagTypeClass
       set TagTypeHtml "<span class=\"datatype datatype-$TagTypeClass\">$TagType</span>"
-      if {$HasTagSummaryVisibility && [dict exists $::osvvm::Report2TestTagSummaryVisibility $TagName]} {
-        set ShowValue [dict get $::osvvm::Report2TestTagSummaryVisibility $TagName]
-        if {[catch {set ShowText [expr {$ShowValue ? "true" : "false"}]}]} {
-          set ShowText "⸻"
+      set ShowText "⸻"
+      if {[dict exists $TagRec Visibility]} {
+        set VisRec [dict get $TagRec Visibility]
+        if {![catch {dict size $VisRec}] && [dict exists $VisRec Summary]} {
+          set ShowValue [dict get $VisRec Summary]
+          if {$ShowValue eq 1 || $ShowValue eq "1" || [string equal -nocase $ShowValue "true"]} {
+            set ShowText "true"
+          } elseif {$ShowValue eq 0 || $ShowValue eq "0" || [string equal -nocase $ShowValue "false"]} {
+            set ShowText "false"
+          }
         }
-        puts $ResultsFile "          <tr><td>$TagName</td><td>$TagDisplayValue</td><td>$TagTypeHtml</td><td>$ShowText</td></tr>"
-      } else {
-        puts $ResultsFile "          <tr><td>$TagName</td><td>$TagDisplayValue</td><td>$TagTypeHtml</td></tr>"
       }
+      puts $ResultsFile "          <tr><td>[EscapeHtml $TagName]</td><td>$TagDisplayValue</td><td>$TagTypeHtml</td><td>$ShowText</td></tr>"
     }
     puts $ResultsFile "        </tbody>"
     puts $ResultsFile "      </table>"

--- a/ReportSimulate2Html.tcl
+++ b/ReportSimulate2Html.tcl
@@ -74,18 +74,107 @@ proc Simulate2Html {SettingsFileWithPath} {
   set BuildName        $::osvvm::Report2BuildName     
   set GenericDict      $::osvvm::Report2GenericDict   
 
-  # Initialize description and tags to empty
+  # Some older/alternate run.yml formats may not include TestCaseFileName.
+  # When possible, derive it from TestCaseName + GenericNames (the file naming convention).
+  if {$TestCaseFileName eq "" && [info exists ::osvvm::Report2GenericNames] && $::osvvm::Report2GenericNames ne ""} {
+    set TestCaseFileName "${TestCaseName}${::osvvm::Report2GenericNames}"
+  }
+
+  # Initialize fields sourced from alerts/build YAML to empty
   set ::osvvm::Report2TestDescription ""
   set ::osvvm::Report2TestTags ""
+  set ::osvvm::Report2TestTagSummaryVisibility ""
+  set ::osvvm::Report2TestStatus ""
+  if {![info exists ::osvvm::Report2TestCaseSimulationTime]} {
+    set ::osvvm::Report2TestCaseSimulationTime ""
+  }
+  if {![info exists ::osvvm::Report2TestCaseElapsedTime]} {
+    set ::osvvm::Report2TestCaseElapsedTime ""
+  }
+
+  # Try to get SimulationTime/ElapsedTime from the build YAML.
+  # Different flows place this file in slightly different locations, so search a few common candidates.
+  set BuildYamlCandidates {}
+  lappend BuildYamlCandidates [file join $::osvvm::Report2BaseDirectory ${BuildName}.yml]
+  lappend BuildYamlCandidates [file join $::osvvm::Report2BaseDirectory ${BuildName}.yaml]
+  if {[info exists ::osvvm::Report2ReportsSubdirectory] && $::osvvm::Report2ReportsSubdirectory ne ""} {
+    lappend BuildYamlCandidates [file join $::osvvm::Report2BaseDirectory $::osvvm::Report2ReportsSubdirectory ${BuildName}.yml]
+    lappend BuildYamlCandidates [file join $::osvvm::Report2BaseDirectory $::osvvm::Report2ReportsSubdirectory ${BuildName}.yaml]
+  }
+  if {[info exists ::osvvm::Report2ReportsDirectory] && $::osvvm::Report2ReportsDirectory ne ""} {
+    lappend BuildYamlCandidates [file join $::osvvm::Report2ReportsDirectory ${BuildName}.yml]
+    lappend BuildYamlCandidates [file join $::osvvm::Report2ReportsDirectory ${BuildName}.yaml]
+  }
+  if {[info exists ::osvvm::Report2ReportsTestSuiteDirectory] && $::osvvm::Report2ReportsTestSuiteDirectory ne ""} {
+    set SuiteReportsBase [file dirname $::osvvm::Report2ReportsTestSuiteDirectory]
+    lappend BuildYamlCandidates [file join $SuiteReportsBase ${BuildName}.yml]
+    lappend BuildYamlCandidates [file join $SuiteReportsBase ${BuildName}.yaml]
+  }
+
+  set BuildYamlFile ""
+  foreach Candidate $BuildYamlCandidates {
+    if {[file exists $Candidate]} {
+      set BuildYamlFile $Candidate
+      break
+    }
+  }
+
+  if {$BuildYamlFile ne ""} {
+    set BuildDict [::yaml::yaml2dict -file $BuildYamlFile]
+    if {[dict exists $BuildDict TestSuites]} {
+      foreach Suite [dict get $BuildDict TestSuites] {
+        if {![dict exists $Suite Name] || ![dict exists $Suite TestCases]} {
+          continue
+        }
+        if {[dict get $Suite Name] ne $TestSuiteName} {
+          continue
+        }
+        set FoundTc 0
+        foreach Tc [dict get $Suite TestCases] {
+          if {[dict exists $Tc TestCaseFileName] && [dict get $Tc TestCaseFileName] eq $TestCaseFileName} {
+            if {[dict exists $Tc SimulationTime] && $::osvvm::Report2TestCaseSimulationTime eq ""} {
+              set ::osvvm::Report2TestCaseSimulationTime [dict get $Tc SimulationTime]
+            }
+            if {[dict exists $Tc ElapsedTime] && $::osvvm::Report2TestCaseElapsedTime eq ""} {
+              set ::osvvm::Report2TestCaseElapsedTime [dict get $Tc ElapsedTime]
+            }
+            set FoundTc 1
+            break
+          }
+        }
+        # Fallback: if no exact file-name match, match by TestCaseName (useful when TestCaseFileName is absent).
+        if {!$FoundTc} {
+          foreach Tc [dict get $Suite TestCases] {
+            if {[dict exists $Tc TestCaseName] && [dict get $Tc TestCaseName] eq $TestCaseName} {
+              if {[dict exists $Tc SimulationTime] && $::osvvm::Report2TestCaseSimulationTime eq ""} {
+                set ::osvvm::Report2TestCaseSimulationTime [dict get $Tc SimulationTime]
+              }
+              if {[dict exists $Tc ElapsedTime] && $::osvvm::Report2TestCaseElapsedTime eq ""} {
+                set ::osvvm::Report2TestCaseElapsedTime [dict get $Tc ElapsedTime]
+              }
+              break
+            }
+          }
+        }
+        break
+      }
+    }
+  }
 
   # Read Description and Tags from Alert YAML file before creating summary table
   if {[file exists ${Report2AlertYamlFile}]} {
     set AlertDict [::yaml::yaml2dict -file ${Report2AlertYamlFile}]
+    if {[dict exists $AlertDict Status]} {
+      set ::osvvm::Report2TestStatus [dict get $AlertDict Status]
+    }
     if {[dict exists $AlertDict Description]} {
       set ::osvvm::Report2TestDescription [dict get $AlertDict Description]
     }
     if {[dict exists $AlertDict Tags]} {
       set ::osvvm::Report2TestTags [dict get $AlertDict Tags]
+    }
+    if {[dict exists $AlertDict TagSummaryVisibility]} {
+      set ::osvvm::Report2TestTagSummaryVisibility [dict get $AlertDict TagSummaryVisibility]
     }
   }
 
@@ -209,6 +298,45 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
 
   puts $ResultsFile "  </div>"
 
+  # Test Result near top (quick essentials)
+  puts $ResultsFile "  <div class=\"TestFacts\">"
+  puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Result</summary>"
+  puts $ResultsFile "      <table class=\"AlertSettings\">"
+  puts $ResultsFile "        <thead><tr><th>Field</th><th>Value</th></tr></thead>"
+  puts $ResultsFile "        <tbody>"
+  set StatusValue "⸻"
+  if {[info exists ::osvvm::Report2TestStatus] && $::osvvm::Report2TestStatus ne ""} {
+    set StatusValue $::osvvm::Report2TestStatus
+  }
+  set SimTimeValue "⸻"
+  if {[info exists ::osvvm::Report2TestCaseSimulationTime] && $::osvvm::Report2TestCaseSimulationTime ne ""} {
+    set SimTimeValue $::osvvm::Report2TestCaseSimulationTime
+  }
+  set ElapsedValue "⸻"
+  if {[info exists ::osvvm::Report2TestCaseElapsedTime] && $::osvvm::Report2TestCaseElapsedTime ne ""} {
+    set ElapsedValue $::osvvm::Report2TestCaseElapsedTime
+  }
+  set StatusClass ""
+  set StatusUpper [string toupper $StatusValue]
+  if {[string first "PASS" $StatusUpper] >= 0} {
+    set StatusClass "passed"
+  } elseif {[string first "FAIL" $StatusUpper] >= 0 || [string first "ERROR" $StatusUpper] >= 0} {
+    set StatusClass "failed"
+  } elseif {[string first "SKIP" $StatusUpper] >= 0} {
+    set StatusClass "skipped"
+  }
+  if {$StatusClass ne ""} {
+    puts $ResultsFile "          <tr><td>Status</td><td><span class=\"$StatusClass\">$StatusValue</span></td></tr>"
+  } else {
+    puts $ResultsFile "          <tr><td>Status</td><td>$StatusValue</td></tr>"
+  }
+  puts $ResultsFile "          <tr><td>ElapsedTime</td><td>$ElapsedValue</td></tr>"
+  puts $ResultsFile "          <tr><td>SuiteName</td><td>$TestSuiteName</td></tr>"
+  puts $ResultsFile "        </tbody>"
+  puts $ResultsFile "      </table>"
+  puts $ResultsFile "    </details>"
+  puts $ResultsFile "  </div>"
+
   # Render Description / Tags / Generics as independent sections
   # (user-requested: Description not in a table; Tags + Generics in tables)
   if {[info exists ::osvvm::Report2TestDescription] && $::osvvm::Report2TestDescription ne ""} {
@@ -223,11 +351,38 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
     puts $ResultsFile "  <div class=\"TestTags\">"
     puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Tags</summary>"
     puts $ResultsFile "      <table class=\"AlertSettings\">"
-    puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th></tr></thead>"
+    set HasTagSummaryVisibility 0
+    if {[info exists ::osvvm::Report2TestTagSummaryVisibility] && $::osvvm::Report2TestTagSummaryVisibility ne ""} {
+      if {![catch {dict size $::osvvm::Report2TestTagSummaryVisibility}] && ([dict size $::osvvm::Report2TestTagSummaryVisibility] > 0)} {
+        set HasTagSummaryVisibility 1
+      }
+    }
+    if {$HasTagSummaryVisibility} {
+      puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th><th>Type</th><th>ShowInSummary</th></tr></thead>"
+    } else {
+      puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th><th>Type</th></tr></thead>"
+    }
     puts $ResultsFile "        <tbody>"
     foreach {TagName TagValue} $::osvvm::Report2TestTags {
       set TagDisplayValue [FormatScalarForHtml $TagValue]
-      puts $ResultsFile "          <tr><td>$TagName</td><td>$TagDisplayValue</td></tr>"
+      if {$TagDisplayValue eq "True" || $TagDisplayValue eq "False"} {
+        set TagType "boolean"
+      } else {
+        set TagType [InferScalarTypeForHtml $TagValue]
+      }
+
+      set TagTypeClass [string tolower $TagType]
+      regsub -all {[^a-z0-9_-]} $TagTypeClass "_" TagTypeClass
+      set TagTypeHtml "<span class=\"datatype datatype-$TagTypeClass\">$TagType</span>"
+      if {$HasTagSummaryVisibility && [dict exists $::osvvm::Report2TestTagSummaryVisibility $TagName]} {
+        set ShowValue [dict get $::osvvm::Report2TestTagSummaryVisibility $TagName]
+        if {[catch {set ShowText [expr {$ShowValue ? "true" : "false"}]}]} {
+          set ShowText "⸻"
+        }
+        puts $ResultsFile "          <tr><td>$TagName</td><td>$TagDisplayValue</td><td>$TagTypeHtml</td><td>$ShowText</td></tr>"
+      } else {
+        puts $ResultsFile "          <tr><td>$TagName</td><td>$TagDisplayValue</td><td>$TagTypeHtml</td></tr>"
+      }
     }
     puts $ResultsFile "        </tbody>"
     puts $ResultsFile "      </table>"
@@ -239,11 +394,49 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
     puts $ResultsFile "  <div class=\"TestGenerics\">"
     puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Generics</summary>"
     puts $ResultsFile "      <table class=\"AlertSettings\">"
-    puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th></tr></thead>"
+    puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th><th>Type</th><th>ShowInSummary</th></tr></thead>"
     puts $ResultsFile "        <tbody>"
+
+    # Determine whether generics are configured to show in the suite summary.
+    # Note: These controls are not stored in YAML today; they reflect the current
+    # script settings (set by SetTestCaseSummaryGenerics/HideTestCaseSummaryGenerics).
+    set ShowGenericsInSummary 1
+    if {[info exists ::osvvm::TestCaseSummaryShowGenerics]} {
+      set ShowGenericsInSummary $::osvvm::TestCaseSummaryShowGenerics
+    }
+    set GenericWhitelist {}
+    if {[info exists ::osvvm::TestCaseSummaryGenericNames]} {
+      set GenericWhitelist $::osvvm::TestCaseSummaryGenericNames
+    }
+
     foreach {GenericName GenericValue} $GenericDict {
       set GenericDisplayValue [FormatGenericValueForHtml $GenericName $GenericValue $::osvvm::Report2GenericNames]
-      puts $ResultsFile "          <tr><td>$GenericName</td><td>$GenericDisplayValue</td></tr>"
+
+      # Infer scalar type (consistent with tag typing).
+      if {$GenericDisplayValue eq "True" || $GenericDisplayValue eq "False"} {
+        set GenericType "boolean"
+      } else {
+        set GenericType [InferScalarTypeForHtml $GenericValue]
+      }
+
+      set GenericTypeClass [string tolower $GenericType]
+      regsub -all {[^a-z0-9_-]} $GenericTypeClass "_" GenericTypeClass
+      set GenericTypeHtml "<span class=\"datatype datatype-$GenericTypeClass\">$GenericType</span>"
+
+      # Compute whether this generic would be shown in the Test Case Summary.
+      if {!$ShowGenericsInSummary} {
+        set GenericShowText "false"
+      } elseif {[llength $GenericWhitelist] == 0} {
+        set GenericShowText "true"
+      } else {
+        if {[lsearch -exact $GenericWhitelist $GenericName] >= 0} {
+          set GenericShowText "true"
+        } else {
+          set GenericShowText "false"
+        }
+      }
+
+      puts $ResultsFile "          <tr><td>$GenericName</td><td>$GenericDisplayValue</td><td>$GenericTypeHtml</td><td>$GenericShowText</td></tr>"
     }
     puts $ResultsFile "        </tbody>"
     puts $ResultsFile "      </table>"

--- a/ReportSimulate2Html.tcl
+++ b/ReportSimulate2Html.tcl
@@ -86,6 +86,7 @@ proc Simulate2Html {SettingsFileWithPath} {
   set ::osvvm::Report2TestBrief ""
   set ::osvvm::Report2TestTags ""
   set ::osvvm::Report2TestTagSummaryVisibility ""
+  set ::osvvm::Report2TestTagTypes ""
   set ::osvvm::Report2TestStatus ""
   if {![info exists ::osvvm::Report2TestCaseSimulationTime]} {
     set ::osvvm::Report2TestCaseSimulationTime ""
@@ -183,6 +184,9 @@ proc Simulate2Html {SettingsFileWithPath} {
     }
     if {[dict exists $AlertDict TagSummaryVisibility]} {
       set ::osvvm::Report2TestTagSummaryVisibility [dict get $AlertDict TagSummaryVisibility]
+    }
+    if {[dict exists $AlertDict TagTypes]} {
+      set ::osvvm::Report2TestTagTypes [dict get $AlertDict TagTypes]
     }
   }
 
@@ -404,10 +408,31 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestDisplayName TestSuiteName
     puts $ResultsFile "        <tbody>"
     foreach {TagName TagValue} $::osvvm::Report2TestTags {
       set TagDisplayValue [FormatScalarForHtml $TagValue]
-      if {$TagDisplayValue eq "True" || $TagDisplayValue eq "False"} {
-        set TagType "boolean"
-      } else {
-        set TagType [InferScalarTypeForHtml $TagValue]
+
+      # Prefer explicit tag types from YAML when available.
+      set TagType ""
+      if {[info exists ::osvvm::Report2TestTagTypes] && $::osvvm::Report2TestTagTypes ne ""} {
+        if {![catch {dict size $::osvvm::Report2TestTagTypes}] && [dict exists $::osvvm::Report2TestTagTypes $TagName]} {
+          set TagTypeToken [dict get $::osvvm::Report2TestTagTypes $TagName]
+          switch -nocase -- $TagTypeToken {
+            TAG_STRING    { set TagType "string" }
+            TAG_BOOL      { set TagType "boolean" }
+            TAG_INT       { set TagType "integer" }
+            TAG_REAL      { set TagType "real" }
+            TAG_TIME      { set TagType "time" }
+            TAG_STD_LOGIC { set TagType "std_logic" }
+            default       { set TagType "" }
+          }
+        }
+      }
+
+      # Backward compatible fallback for older YAML (no TagTypes)
+      if {$TagType eq ""} {
+        if {$TagDisplayValue eq "True" || $TagDisplayValue eq "False"} {
+          set TagType "boolean"
+        } else {
+          set TagType [InferScalarTypeForHtml $TagValue]
+        }
       }
 
       set TagTypeClass [string tolower $TagType]

--- a/ReportSimulate2Html.tcl
+++ b/ReportSimulate2Html.tcl
@@ -81,7 +81,9 @@ proc Simulate2Html {SettingsFileWithPath} {
   }
 
   # Initialize fields sourced from alerts/build YAML to empty
+  set ::osvvm::Report2TestTitle ""
   set ::osvvm::Report2TestDescription ""
+  set ::osvvm::Report2TestBrief ""
   set ::osvvm::Report2TestTags ""
   set ::osvvm::Report2TestTagSummaryVisibility ""
   set ::osvvm::Report2TestStatus ""
@@ -167,6 +169,12 @@ proc Simulate2Html {SettingsFileWithPath} {
     if {[dict exists $AlertDict Status]} {
       set ::osvvm::Report2TestStatus [dict get $AlertDict Status]
     }
+    if {[dict exists $AlertDict Title]} {
+      set ::osvvm::Report2TestTitle [dict get $AlertDict Title]
+    }
+    if {[dict exists $AlertDict Brief]} {
+      set ::osvvm::Report2TestBrief [dict get $AlertDict Brief]
+    }
     if {[dict exists $AlertDict Description]} {
       set ::osvvm::Report2TestDescription [dict get $AlertDict Description]
     }
@@ -178,7 +186,16 @@ proc Simulate2Html {SettingsFileWithPath} {
     }
   }
 
-  CreateTestCaseSummaryTable ${TestCaseName} ${TestSuiteName} ${BuildName} ${GenericDict}
+  # Compute display name for the HTML page: prefer Title when set.
+  set TestDisplayName $TestCaseName
+  if {[info exists ::osvvm::Report2TestTitle]} {
+    set CandidateTitle [string trim $::osvvm::Report2TestTitle]
+    if {$CandidateTitle ne ""} {
+      set TestDisplayName $CandidateTitle
+    }
+  }
+
+  CreateTestCaseSummaryTable ${TestCaseName} ${TestDisplayName} ${TestSuiteName} ${BuildName} ${GenericDict}
   
   if {[file exists ${Report2AlertYamlFile}]} {
     Alert2Html ${TestCaseName} ${TestSuiteName} ${Report2AlertYamlFile}
@@ -214,12 +231,12 @@ proc OpenSimulationReportFile {FileName {initialize 0}} {
 }
 
 #--------------------------------------------------------------
-proc CreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName GenericDict} {
+proc CreateTestCaseSummaryTable {TestCaseName TestDisplayName TestSuiteName BuildName GenericDict} {
   variable ResultsFile
 
   OpenSimulationReportFile [file join $::osvvm::Report2TestCaseHtml] 1
 
-  set ErrorCode [catch {LocalCreateTestCaseSummaryTable $TestCaseName $TestSuiteName $BuildName $GenericDict} errmsg]
+  set ErrorCode [catch {LocalCreateTestCaseSummaryTable $TestCaseName $TestDisplayName $TestSuiteName $BuildName $GenericDict} errmsg]
   
   close $ResultsFile
 
@@ -229,7 +246,7 @@ proc CreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName GenericDic
 }
 
 #--------------------------------------------------------------
-proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName GenericDict} {
+proc LocalCreateTestCaseSummaryTable {TestCaseName TestDisplayName TestSuiteName BuildName GenericDict} {
   variable ResultsFile
 
   
@@ -239,7 +256,7 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
     set ReportsPrefix "../.."
   }
 
-  CreateOsvvmReportHeader $ResultsFile "$TestCaseName Test Case Report" $ReportsPrefix
+  CreateOsvvmReportHeader $ResultsFile "$TestDisplayName Test Case Report" $ReportsPrefix
 
 
   puts $ResultsFile "  <div class=\"summary-parent\">"
@@ -300,7 +317,7 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
 
   # Test Result near top (quick essentials)
   puts $ResultsFile "  <div class=\"TestFacts\">"
-  puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Result</summary>"
+  puts $ResultsFile "    <details open><summary class=\"subtitle testcase-section-heading\"><span class=\"tc-name\">[EscapeHtml $TestDisplayName]</span><span class=\"tc-sep\"> — </span><span class=\"tc-suffix\">Summary</span></summary>"
   puts $ResultsFile "      <table class=\"AlertSettings\">"
   puts $ResultsFile "        <thead><tr><th>Field</th><th>Value</th></tr></thead>"
   puts $ResultsFile "        <tbody>"
@@ -330,8 +347,30 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
   } else {
     puts $ResultsFile "          <tr><td>Status</td><td>$StatusValue</td></tr>"
   }
-  puts $ResultsFile "          <tr><td>ElapsedTime</td><td>$ElapsedValue</td></tr>"
-  puts $ResultsFile "          <tr><td>SuiteName</td><td>$TestSuiteName</td></tr>"
+  puts $ResultsFile "          <tr><td>Elapsed Time</td><td>$ElapsedValue</td></tr>"
+  puts $ResultsFile "          <tr><td>Suite Name</td><td>$TestSuiteName</td></tr>"
+
+  # Include the VHDL test case source file name when available
+  set TestCaseSourceFileName "⸻"
+  if {[info exists ::osvvm::Report2TestCaseFile] && $::osvvm::Report2TestCaseFile ne ""} {
+    set TestCaseSourceFileName [file tail $::osvvm::Report2TestCaseFile]
+  }
+  puts $ResultsFile "          <tr><td>File</td><td>[EscapeHtml $TestCaseSourceFileName]</td></tr>"
+
+  # Include Title (only when explicitly set; no fallback)
+  set TitleValue "⸻"
+  if {[info exists ::osvvm::Report2TestTitle] && [string trim $::osvvm::Report2TestTitle] ne ""} {
+    set TitleValue $::osvvm::Report2TestTitle
+  }
+  puts $ResultsFile "          <tr><td>Title</td><td>[EscapeHtml $TitleValue]</td></tr>"
+
+  # Include Brief (only when explicitly set; no fallback)
+  set BriefValue "⸻"
+  if {[info exists ::osvvm::Report2TestBrief] && [string trim $::osvvm::Report2TestBrief] ne ""} {
+    set BriefValue $::osvvm::Report2TestBrief
+  }
+  puts $ResultsFile "          <tr><td>Brief</td><td>[EscapeHtml $BriefValue]</td></tr>"
+
   puts $ResultsFile "        </tbody>"
   puts $ResultsFile "      </table>"
   puts $ResultsFile "    </details>"
@@ -341,7 +380,7 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
   # (user-requested: Description not in a table; Tags + Generics in tables)
   if {[info exists ::osvvm::Report2TestDescription] && $::osvvm::Report2TestDescription ne ""} {
     puts $ResultsFile "  <div class=\"TestDescription\">"
-    puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Description</summary>"
+    puts $ResultsFile "    <details open><summary class=\"subtitle testcase-section-heading\"><span class=\"tc-name\">[EscapeHtml $TestDisplayName]</span><span class=\"tc-sep\"> — </span><span class=\"tc-suffix\">Description</span></summary>"
     WriteMarkdownSubsetAsHtml $ResultsFile $::osvvm::Report2TestDescription "      "
     puts $ResultsFile "    </details>"
     puts $ResultsFile "  </div>"
@@ -349,7 +388,7 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
 
   if {[info exists ::osvvm::Report2TestTags] && $::osvvm::Report2TestTags ne ""} {
     puts $ResultsFile "  <div class=\"TestTags\">"
-    puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Tags</summary>"
+    puts $ResultsFile "    <details open><summary class=\"subtitle testcase-section-heading\"><span class=\"tc-name\">[EscapeHtml $TestDisplayName]</span><span class=\"tc-sep\"> — </span><span class=\"tc-suffix\">Tags</span></summary>"
     puts $ResultsFile "      <table class=\"AlertSettings\">"
     set HasTagSummaryVisibility 0
     if {[info exists ::osvvm::Report2TestTagSummaryVisibility] && $::osvvm::Report2TestTagSummaryVisibility ne ""} {
@@ -392,7 +431,7 @@ proc LocalCreateTestCaseSummaryTable {TestCaseName TestSuiteName BuildName Gener
 
   if {${GenericDict} ne ""} {
     puts $ResultsFile "  <div class=\"TestGenerics\">"
-    puts $ResultsFile "    <details open><summary class=\"subtitle\">$TestCaseName Generics</summary>"
+    puts $ResultsFile "    <details open><summary class=\"subtitle testcase-section-heading\"><span class=\"tc-name\">[EscapeHtml $TestDisplayName]</span><span class=\"tc-sep\"> — </span><span class=\"tc-suffix\">Generics</span></summary>"
     puts $ResultsFile "      <table class=\"AlertSettings\">"
     puts $ResultsFile "        <thead><tr><th>Name</th><th>Value</th><th>Type</th><th>ShowInSummary</th></tr></thead>"
     puts $ResultsFile "        <tbody>"

--- a/ReportSupport.tcl
+++ b/ReportSupport.tcl
@@ -111,6 +111,7 @@ proc FormatInlineMarkdownSubset {EscapedText} {
 #   - Paragraphs separated by blank lines
 #   - Headings: ## and ###
 #   - Bullet list items: - 
+#   - Enumerated list items: 1. 
 #   - Inline: **bold**, *italic*
 #
 proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
@@ -118,7 +119,8 @@ proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
   set Normalized [string map {"\r\n" "\n" "\r" "\n"} $Text]
   set Lines [split $Normalized "\n"]
 
-  set InList 0
+  # "" | "ul" | "ol"
+  set ListKind ""
   set ParaLines {}
 
   proc _FlushParagraph {ResultsFile Indent ParaLinesVar} {
@@ -133,11 +135,11 @@ proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
     set ParaLines {}
   }
 
-  proc _CloseListIfOpen {ResultsFile Indent InListVar} {
-    upvar 1 $InListVar InList
-    if {$InList} {
-      puts $ResultsFile "${Indent}</ul>"
-      set InList 0
+  proc _CloseListIfOpen {ResultsFile Indent ListKindVar} {
+    upvar 1 $ListKindVar ListKind
+    if {$ListKind ne ""} {
+      puts $ResultsFile "${Indent}</${ListKind}>"
+      set ListKind ""
     }
   }
 
@@ -147,13 +149,13 @@ proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
 
     if {$Trimmed eq ""} {
       _FlushParagraph $ResultsFile $Indent ParaLines
-      _CloseListIfOpen $ResultsFile $Indent InList
+      _CloseListIfOpen $ResultsFile $Indent ListKind
       continue
     }
 
     if {[string match "## *" $Trimmed] || [string match "### *" $Trimmed]} {
       _FlushParagraph $ResultsFile $Indent ParaLines
-      _CloseListIfOpen $ResultsFile $Indent InList
+      _CloseListIfOpen $ResultsFile $Indent ListKind
 
       if {[string match "### *" $Trimmed]} {
         set Title [string range $Trimmed 4 end]
@@ -170,9 +172,10 @@ proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
 
     if {[string match "- *" $Trimmed]} {
       _FlushParagraph $ResultsFile $Indent ParaLines
-      if {!$InList} {
+      if {$ListKind ne "ul"} {
+        _CloseListIfOpen $ResultsFile $Indent ListKind
         puts $ResultsFile "${Indent}<ul>"
-        set InList 1
+        set ListKind "ul"
       }
       set Item [string range $Trimmed 2 end]
       set Escaped [EscapeHtml $Item]
@@ -181,14 +184,27 @@ proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
       continue
     }
 
-    if {$InList} {
-      _CloseListIfOpen $ResultsFile $Indent InList
+    if {[regexp {^\d+\.\s+(.+)$} $Trimmed -> Item]} {
+      _FlushParagraph $ResultsFile $Indent ParaLines
+      if {$ListKind ne "ol"} {
+        _CloseListIfOpen $ResultsFile $Indent ListKind
+        puts $ResultsFile "${Indent}<ol>"
+        set ListKind "ol"
+      }
+      set Escaped [EscapeHtml $Item]
+      set Html [FormatInlineMarkdownSubset $Escaped]
+      puts $ResultsFile "${Indent}  <li>${Html}</li>"
+      continue
+    }
+
+    if {$ListKind ne ""} {
+      _CloseListIfOpen $ResultsFile $Indent ListKind
     }
     lappend ParaLines $Line
   }
 
   _FlushParagraph $ResultsFile $Indent ParaLines
-  _CloseListIfOpen $ResultsFile $Indent InList
+  _CloseListIfOpen $ResultsFile $Indent ListKind
 }
 
 # -------------------------------------------------
@@ -307,6 +323,16 @@ proc GetOsvvmPathSettings {TestDict} {
   variable ::osvvm::Report2CoverageSubdirectory         [dict get $SettingsInfoDict CoverageSubdirectory]
   variable ::osvvm::Report2CssFiles                     [dict get $SettingsInfoDict Report2CssFiles]
   variable ::osvvm::Report2PngFile                      [dict get $SettingsInfoDict Report2PngFile]
+}
+
+# -------------------------------------------------
+# SumAlertCount
+#
+# Used by multiple report generators.
+if {![llength [info commands SumAlertCount]]} {
+  proc SumAlertCount {AlertCountDict} {
+    return [expr [dict get $AlertCountDict Failure] + [dict get $AlertCountDict Error] + [dict get $AlertCountDict Warning]]
+  }
 }
 
 # -------------------------------------------------

--- a/ReportSupport.tcl
+++ b/ReportSupport.tcl
@@ -42,6 +42,156 @@
 package require yaml
 
 # -------------------------------------------------
+# FormatGenericValueForHtml
+#
+# YAML boolean scalars may load into Tcl as 0/1. For generics, prefer showing
+# True/False in HTML (matching VHDL/OSVVM conventions) when we can infer the
+# original boolean value from the encoded GenericNames/TestCaseFileName string.
+#
+proc FormatGenericValueForHtml {GenericName GenericValue {GenericNames ""}} {
+  set EncodedGenericName $GenericName
+  if {[string match "G_*" $EncodedGenericName]} {
+    set EncodedGenericName [string range $EncodedGenericName 2 end]
+  }
+
+  if {$GenericNames ne ""} {
+    if {[string first "_G_${EncodedGenericName}_TRUE"  $GenericNames] >= 0} { return "True" }
+    if {[string first "_G_${EncodedGenericName}_FALSE" $GenericNames] >= 0} { return "False" }
+  }
+
+  if {[string equal -nocase $GenericValue "true"]}  { return "True" }
+  if {[string equal -nocase $GenericValue "false"]} { return "False" }
+
+  return $GenericValue
+}
+
+# -------------------------------------------------
+# FormatScalarForHtml
+#
+# YAML booleans commonly load into Tcl as 0/1. For HTML reports, render
+# booleans as True/False.
+#
+proc FormatScalarForHtml {Value} {
+  if {[string equal -nocase $Value "true"]}  { return "True" }
+  if {[string equal -nocase $Value "false"]} { return "False" }
+
+  # Heuristic: yaml::yaml2dict represents YAML booleans as Tcl 0/1
+  if {$Value eq 1 || $Value eq "1"} { return "True" }
+  if {$Value eq 0 || $Value eq "0"} { return "False" }
+
+  return $Value
+}
+
+# -------------------------------------------------
+# EscapeHtml
+#
+proc EscapeHtml {Text} {
+  set Escaped $Text
+  set Escaped [string map [list "&" "&amp;" "<" "&lt;" ">" "&gt;" "\"" "&quot;" "'" "&#39;"] $Escaped]
+  return $Escaped
+}
+
+# -------------------------------------------------
+# FormatInlineMarkdownSubset
+#
+# Supports **bold** and *italic*.
+# Input must already be HTML-escaped.
+
+proc FormatInlineMarkdownSubset {EscapedText} {
+  set S $EscapedText
+  regsub -all {\*\*([^*]+)\*\*} $S {<strong>\1</strong>} S
+  regsub -all {\*([^*]+)\*} $S {<em>\1</em>} S
+  return $S
+}
+
+# -------------------------------------------------
+# WriteMarkdownSubsetAsHtml
+#
+# Minimal Markdown subset:
+#   - Paragraphs separated by blank lines
+#   - Headings: ## and ###
+#   - Bullet list items: - 
+#   - Inline: **bold**, *italic*
+#
+proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
+  # Normalize newlines
+  set Normalized [string map {"\r\n" "\n" "\r" "\n"} $Text]
+  set Lines [split $Normalized "\n"]
+
+  set InList 0
+  set ParaLines {}
+
+  proc _FlushParagraph {ResultsFile Indent ParaLinesVar} {
+    upvar 1 $ParaLinesVar ParaLines
+    if {[llength $ParaLines] == 0} {
+      return
+    }
+    set Raw [join $ParaLines " "]
+    set Escaped [EscapeHtml $Raw]
+    set Html [FormatInlineMarkdownSubset $Escaped]
+    puts $ResultsFile "${Indent}<p>${Html}</p>"
+    set ParaLines {}
+  }
+
+  proc _CloseListIfOpen {ResultsFile Indent InListVar} {
+    upvar 1 $InListVar InList
+    if {$InList} {
+      puts $ResultsFile "${Indent}</ul>"
+      set InList 0
+    }
+  }
+
+  foreach Line $Lines {
+    set Line [string trimright $Line]
+    set Trimmed [string trim $Line]
+
+    if {$Trimmed eq ""} {
+      _FlushParagraph $ResultsFile $Indent ParaLines
+      _CloseListIfOpen $ResultsFile $Indent InList
+      continue
+    }
+
+    if {[string match "## *" $Trimmed] || [string match "### *" $Trimmed]} {
+      _FlushParagraph $ResultsFile $Indent ParaLines
+      _CloseListIfOpen $ResultsFile $Indent InList
+
+      if {[string match "### *" $Trimmed]} {
+        set Title [string range $Trimmed 4 end]
+        set Tag "h4"
+      } else {
+        set Title [string range $Trimmed 3 end]
+        set Tag "h3"
+      }
+      set Escaped [EscapeHtml $Title]
+      set Html [FormatInlineMarkdownSubset $Escaped]
+      puts $ResultsFile "${Indent}<${Tag} class=\"subtitle\">${Html}</${Tag}>"
+      continue
+    }
+
+    if {[string match "- *" $Trimmed]} {
+      _FlushParagraph $ResultsFile $Indent ParaLines
+      if {!$InList} {
+        puts $ResultsFile "${Indent}<ul>"
+        set InList 1
+      }
+      set Item [string range $Trimmed 2 end]
+      set Escaped [EscapeHtml $Item]
+      set Html [FormatInlineMarkdownSubset $Escaped]
+      puts $ResultsFile "${Indent}  <li>${Html}</li>"
+      continue
+    }
+
+    if {$InList} {
+      _CloseListIfOpen $ResultsFile $Indent InList
+    }
+    lappend ParaLines $Line
+  }
+
+  _FlushParagraph $ResultsFile $Indent ParaLines
+  _CloseListIfOpen $ResultsFile $Indent InList
+}
+
+# -------------------------------------------------
 # CreateOsvvmReportHeader
 #
 proc CreateOsvvmReportHeader {ResultsFile ReportName {RelativePath ""} {IncludeLogo 0} } {

--- a/ReportSupport.tcl
+++ b/ReportSupport.tcl
@@ -83,6 +83,45 @@ proc FormatScalarForHtml {Value} {
 }
 
 # -------------------------------------------------
+# InferScalarTypeForHtml
+#
+# Best-effort type inference for scalar values loaded from YAML.
+# Used by the per-test HTML page to display a "Type" column for tags.
+#
+proc InferScalarTypeForHtml {Value} {
+  # Normalize to string for regex checks.
+  set S "${Value}"
+
+  # Boolean
+  if {[string equal -nocase $S "true"] || [string equal -nocase $S "false"]} {
+    return "boolean"
+  }
+
+  # Heuristic: yaml::yaml2dict commonly maps YAML booleans to Tcl 0/1
+  if {$S eq "0" || $S eq "1"} {
+    return "boolean"
+  }
+
+  # Time: number + unit (common VHDL time units)
+  # Examples: 100 ns, 5ps, 1.25 us
+  if {[regexp -nocase {^\s*[-+]?\d+(?:\.\d+)?\s*(fs|ps|ns|us|ms|s|sec|secs|second|seconds|min|mins|minute|minutes|hr|hrs|hour|hours)\s*$} $S]} {
+    return "time"
+  }
+
+  # Integer
+  if {[string is integer -strict $S]} {
+    return "integer"
+  }
+
+  # Real
+  if {[string is double -strict $S]} {
+    return "real"
+  }
+
+  return "string"
+}
+
+# -------------------------------------------------
 # EscapeHtml
 #
 proc EscapeHtml {Text} {
@@ -95,13 +134,138 @@ proc EscapeHtml {Text} {
 # -------------------------------------------------
 # FormatInlineMarkdownSubset
 #
-# Supports **bold** and *italic*.
+# Minimal inline Markdown subset:
+#   - Escapes for literals using backslash: \*, \#, \[, \], \(, \), \`, \-, \\
+#   - Inline code using backticks: `code`
+#   - Links: [text](url)
+#       - Allowed URL schemes/targets: https://, http://, #anchors, /absolute, ./relative, ../relative
+#       - Other URLs are rendered as plain text (not a link)
+#   - Emphasis: **bold** and *italic*
+#
 # Input must already be HTML-escaped.
+
+proc _IsSafeMarkdownUrl {Url} {
+  set U [string trim $Url]
+  if {$U eq ""} {
+    return 0
+  }
+  if {[regexp {\s} $U]} {
+    return 0
+  }
+  if {[regexp -nocase {^https?://} $U]} {
+    return 1
+  }
+  if {[string match "#*" $U]} {
+    return 1
+  }
+  if {[string match "/*" $U]} {
+    return 1
+  }
+  if {[string match "./*" $U] || [string match "../*" $U]} {
+    return 1
+  }
+  return 0
+}
+
+proc _ProtectInlineCodeSpans {S CodeMapVar} {
+  upvar 1 $CodeMapVar CodeMap
+  set Out ""
+  set Remainder $S
+  set I 0
+  while {[regexp -indices {`([^`]+)`} $Remainder MatchIdx CodeIdx]} {
+    lassign $MatchIdx M0 M1
+    lassign $CodeIdx C0 C1
+
+    if {$M0 > 0} {
+      append Out [string range $Remainder 0 [expr {$M0 - 1}]]
+    }
+
+    set CodeText [string range $Remainder $C0 $C1]
+    set Token "\uE000${I}\uE001"
+    set CodeMap($Token) $CodeText
+    append Out $Token
+    incr I
+
+    set Remainder [string range $Remainder [expr {$M1 + 1}] end]
+  }
+  append Out $Remainder
+  return $Out
+}
+
+proc _RestoreInlineCodeSpans {S CodeMapVar} {
+  upvar 1 $CodeMapVar CodeMap
+  set Out $S
+  foreach Token [lsort -dictionary [array names CodeMap]] {
+    set Out [string map [list $Token "<code>$CodeMap($Token)</code>"] $Out]
+  }
+  return $Out
+}
 
 proc FormatInlineMarkdownSubset {EscapedText} {
   set S $EscapedText
+
+  # Handle backslash escapes first so escaped markup is treated as literal.
+  # Use control characters as placeholders to avoid interacting with later regex.
+  set TOK_BSLASH "\u0001"
+  set TOK_STAR   "\u0002"
+  set TOK_HASH   "\u0003"
+  set TOK_LB     "\u0004"
+  set TOK_RB     "\u0005"
+  set TOK_LP     "\u0006"
+  set TOK_RP     "\u0007"
+  set TOK_BT     "\u0008"
+  set TOK_DASH   "\u0009"
+  set S [string map [list {\\} $TOK_BSLASH {\*} $TOK_STAR {\#} $TOK_HASH {\[} $TOK_LB {\]} $TOK_RB {\(} $TOK_LP {\)} $TOK_RP {\`} $TOK_BT {\-} $TOK_DASH] $S]
+
+  # Protect inline code spans so other formatting does not apply inside them.
+  array set CodeMap {}
+  set S [_ProtectInlineCodeSpans $S CodeMap]
+
+  # Links: [text](url)
+  # Note: Both text and url are already HTML-escaped here.
+  set Out ""
+  set Remainder $S
+  while {[regexp -indices {\[([^\]]+)\]\(([^\)]+)\)} $Remainder MatchIdx TextIdx UrlIdx]} {
+    lassign $MatchIdx M0 M1
+    lassign $TextIdx T0 T1
+    lassign $UrlIdx U0 U1
+
+    if {$M0 > 0} {
+      append Out [string range $Remainder 0 [expr {$M0 - 1}]]
+    }
+
+    set LinkText [string range $Remainder $T0 $T1]
+    set LinkUrl  [string range $Remainder $U0 $U1]
+    if {[_IsSafeMarkdownUrl $LinkUrl]} {
+      append Out "<a href=\"$LinkUrl\">$LinkText</a>"
+    } else {
+      append Out "$LinkText ($LinkUrl)"
+    }
+
+    set Remainder [string range $Remainder [expr {$M1 + 1}] end]
+  }
+  append Out $Remainder
+  set S $Out
+
+  # Emphasis
   regsub -all {\*\*([^*]+)\*\*} $S {<strong>\1</strong>} S
   regsub -all {\*([^*]+)\*} $S {<em>\1</em>} S
+
+  # Restore inline code spans
+  set S [_RestoreInlineCodeSpans $S CodeMap]
+
+  # Restore escaped literals
+  set S [string map [list \
+    $TOK_BSLASH "\\" \
+    $TOK_STAR {*} \
+    $TOK_HASH {#} \
+    $TOK_LB {[} \
+    $TOK_RB {]} \
+    $TOK_LP {(} \
+    $TOK_RP {)} \
+    $TOK_BT {`} \
+    $TOK_DASH {-} \
+  ] $S]
   return $S
 }
 
@@ -110,10 +274,10 @@ proc FormatInlineMarkdownSubset {EscapedText} {
 #
 # Minimal Markdown subset:
 #   - Paragraphs separated by blank lines
-#   - Headings: ## and ###
+#   - Headings: ##, ###, ####, #####
 #   - Bullet list items: - 
 #   - Enumerated list items: 1. 
-#   - Inline: **bold**, *italic*
+#   - Inline: **bold**, *italic*, `code`, [text](url), and backslash escapes
 #
 proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
   # Normalize newlines
@@ -154,16 +318,19 @@ proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
       continue
     }
 
-    if {[string match "## *" $Trimmed] || [string match "### *" $Trimmed]} {
+    if {[regexp {^(#{2,5})\s+(.+)$} $Trimmed -> Hashes Title]} {
       _FlushParagraph $ResultsFile $Indent ParaLines
       _CloseListIfOpen $ResultsFile $Indent ListKind
 
-      if {[string match "### *" $Trimmed]} {
-        set Title [string range $Trimmed 4 end]
-        set Tag "h4"
-      } else {
-        set Title [string range $Trimmed 3 end]
+      set Level [string length $Hashes]
+      if {$Level == 2} {
         set Tag "h3"
+      } elseif {$Level == 3} {
+        set Tag "h4"
+      } elseif {$Level == 4} {
+        set Tag "h5"
+      } else {
+        set Tag "h6"
       }
       set Escaped [EscapeHtml $Title]
       set Html [FormatInlineMarkdownSubset $Escaped]
@@ -358,6 +525,11 @@ proc GetTestCaseSettings {SettingsFileName} {
   variable ::osvvm::Report2TranscriptFiles              [dict get $TestDict TranscriptFiles     ]
 
   variable ::osvvm::Report2TestCaseHtml [file join $Report2TestSuiteDirectory ${Report2TestCaseFileName}.html]
+
+  # Optional fields (older run.yml files may not have these)
+  if {[dict exists $TestDict ElapsedTime]} {
+    variable ::osvvm::Report2TestCaseElapsedTime [dict get $TestDict ElapsedTime]
+  }
   
   GetOsvvmPathSettings $TestDict
   

--- a/ReportSupport.tcl
+++ b/ReportSupport.tcl
@@ -86,7 +86,8 @@ proc FormatScalarForHtml {Value} {
 # EscapeHtml
 #
 proc EscapeHtml {Text} {
-  set Escaped $Text
+  # Strip ASCII control chars that can break HTML rendering.
+  regsub -all {[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]} $Text { } Escaped
   set Escaped [string map [list "&" "&amp;" "<" "&lt;" ">" "&gt;" "\"" "&quot;" "'" "&#39;"] $Escaped]
   return $Escaped
 }

--- a/ReportSupport.tcl
+++ b/ReportSupport.tcl
@@ -318,7 +318,9 @@ proc WriteMarkdownSubsetAsHtml {ResultsFile Text {Indent ""}} {
       continue
     }
 
-    if {[regexp {^(#{2,5})\s+(.+)$} $Trimmed -> Hashes Title]} {
+    # Support headings written as \##, \###, ... (workaround for YAML parsers
+    # that incorrectly treat lines starting with '#' as comments inside | blocks).
+    if {[regexp {^\\?(#{2,5})\s+(.+)$} $Trimmed -> Hashes Title]} {
       _FlushParagraph $ResultsFile $Indent ParaLines
       _CloseListIfOpen $ResultsFile $Indent ListKind
 


### PR DESCRIPTION
## Summary

This PR enhances OSVVM report metadata and presentation across YAML, HTML, and JUnit XML outputs.

### New metadata features
- **Test Title (display-only)**: Added test Title support (VHDL API + storage) with fallback-to-name behavior in HTML where a human-readable label is needed, while keeping the test **Name** as the stable identifier for filenames/anchors.
- **Test Suite Title (display-only)**: Added suite-level Title with the same “display vs identifier” split: suite **Name** remains the stable ID, suite **Title** is used for report display with fallback.
- **Suite Description / Suite Brief**: Added suite-level description and brief support in build YAML and HTML.
- **Test Brief**: Added/extended test brief management and ensured report behavior matches intent.
- **Test Tags**: Added support for per-test tags (name/value pairs) to capture important test context such as configuration values, modes, key signals/parameters, or any other “this run matters because …” information you want visible in reports. Tags include optional **visibility control** (whether a tag appears in the Test Case Summary table columns vs only on the testcase page/details).

### Report generation changes
- **YAML**
	- Emits suite fields such as `Title`, `Brief`, `Description` when set.
	- Emits test fields such as `Title`, `Brief`, `Description`, `Tags`, plus tag visibility metadata.
	- Tag values in YAML are emitted as native scalars where possible (for example: integer, real, boolean) as well as strings (for example: integer values like `burstlength: 256`), so report generators can preserve type information.
- **HTML build reports**
	- Shows **Title** (suite/test) where appropriate, with clean fallback to Name.
	- **Conditionally renders Brief columns** in suite/testcase summary tables only if at least one entry has an explicit Brief.
	- Adds styling improvements for readability:
		- “<name> — <section>” headings with a strong separator and de-emphasized suffix.
		- Prevents wrapping of long Titles in key first columns (suite and testcase summary tables) to avoid overly narrow columns.
- **HTML testcase pages**
	- Adds **Brief** and **testcase source filename** into the testcase “Summary” table.
	- Uses Title (fallback to Name) consistently across headings.
	- Updates Alert section headings (**Alert Report / Alert Settings / Alert Results**) to follow the same heading styling.
	- Ensures Alert Results top-level row uses Title (fallback) while keeping child alert names unchanged.
- **JUnit XML**
	- Adds `title` / `brief` properties when present.

### Configuration & formatting utilities
- **Generics enhancement (columns)**: Testcase **Generics** can be shown as columns in the Test Case Summary table (so key configuration values are visible at a glance).
- **Configurable generic selection**: Which Generics become columns is configurable (e.g., whitelist key generics you care about), with controls such as max-columns.
- Added configuration APIs for controlling which **Tags** appear in Test Case Summary tables (including whitelists and max-columns).
- Added scalar formatting helpers (including datatype inference) and HTML escaping improvements.
- Added HTML enhancements such as datatype badges and elapsed time presentation (as applicable by report type).

### VHDL API additions (OSVVM/AlertLogPkg.vhd)
- **Test Title API**: `SetTestTitle`, `GetTestTitle`, `ClearTestTitle`.
- **Extended `SetTestName`**: `SetTestName(Name, Title => "...")` to set a stable identifier plus an optional display title.
- **Test Brief API**: `SetTestBrief`, `GetTestBrief`, `ClearTestBrief`.
- **Test Tags API**: `SetTestTag(TagName, TagValue, ShowInSummary => ...)` overloads for common types (string/boolean/integer/time/real/std_logic), including control over whether each tag appears in summary tables.

## Usage

```TCL
TestSuite TestSuiteDemo
SetTestSuiteTitle "Demo Suite name"
SetTestSuiteBrief "Demonstrates suite-level descriptions (in the .pro file) and test-case descriptions/tags (in VHDL)"

# Test Case Summary: hide all generics except G_WIDTH
# If all Generics need to be shown, do not call SetTestCaseSummaryGenerics
SetTestCaseSummaryGenerics G_WIDTH
# Run the two test architectures
RunTest TestDescription_Demo1.vhd [generic G_WIDTH 32] [generic G_PERIOD "10ns"] [generic G_CFG1 TRUE ] [generic G_CFG2 FALSE]
RunTest TestDescription_Demo2.vhd [generic G_WIDTH 8 ] [generic G_PERIOD "5ns" ] [generic G_CFG1 FALSE] [generic G_CFG2 TRUE]
```

```VHDL
  -- Important test configuration signals/constants that need to be reported in the test case
  signal DataWidth    : natural := 8 ;
  signal BurstLength  : natural := 256 ;
  signal SyncRegs     : boolean := TRUE ;
  signal BufferEnable : boolean := FALSE ;
  constant delay_time : time := 100 ns ;
  signal cfg_real     : real := 3.14 ;
```

```VHDL
    -- Set test name to match the entity(architecture) name
    -- SetTestName("TestDescription_Demo1") ;
    SetTestName("TestDescription_Demo1", "Burst test without back-pressure") ;
    SetTestBrief("This is a short summary of TestDescription_Demo1") ;

    -- Set Test Description using Markdown subset
    SetTestDescription(
      "This demo shows how to document a test case using a *formatted* description." & LF &
      "The goal is to keep it readable in both YAML and HTML." & LF & LF &
      "## What this test does" & LF &
      "- Exercises a simple pass case" & LF &
      "- Demonstrates **bold** and *italic* emphasis" & LF &
      "- Demonstrates bullet lists" & LF &
      "- Demonstrates inline code like `SetTestTag(""Name"", Value)`" & LF &
      "- Demonstrates links like [OSVVM docs](https://osvvm.github.io)" & LF &
      "- Demonstrates links like [Other link](/home/user/local/path/example)" & LF & LF &
      "### Notes" & LF &
      "Use SetTestTag for structured metadata; use Description for narrative context." & LF &
      "Keep formatting simple and consistent." & LF & LF &
      "#### More heading levels" & LF &
      "This is a level-4 heading (####)." & LF &
      "#### Escapes for literals" & LF &
      "Use backslash escapes to show markup characters literally:" & LF &
        "- \* shows a literal asterisk: \*not italic\*" & LF &
        "- \# shows a literal hash: \#not a heading" & LF &
        "- \` shows a literal backtick: \`not code\`" & LF
    ) ;
    
    -- Set configuration tags as key-value pairs
    -- Tags are visible in the Test Case Summary table by default.
    -- Use the optional 3rd argument to hide less-important tags from the summary.
    SetTestTag("Cfg", "CFG_2", FALSE) ;
    SetTestTag("Scenario", "Maximum Burst", FALSE) ;
    SetTestTag("Priority", "Medium", FALSE) ;
    SetTestTag("Condition", "Back-pressure Active", FALSE) ;
    -- For consistency, the actual name and value can be passed through
    SetTestTag(DataWidth'simple_name, DataWidth, FALSE) ;
    SetTestTag(BurstLength'simple_name, BurstLength) ;
    SetTestTag(SyncRegs'simple_name, SyncRegs) ;
    SetTestTag(BufferEnable'simple_name, BufferEnable) ;
    SetTestTag(delay_time'simple_name, delay_time) ;
    SetTestTag(cfg_real'simple_name, cfg_real) ;

```

## Screenshots

Test Suite Summary table:

<img width="1901" height="338" alt="test suite tables" src="https://github.com/user-attachments/assets/6d9b9d1a-60f3-46e1-8689-bbaa62d53985" />

Added test case summary table:

<img width="495" height="214" alt="test case summary table" src="https://github.com/user-attachments/assets/a2a2a653-d7e9-49db-9b94-73de56d1eed4" />

Markdown subset example:

<img width="884" height="492" alt="test case description section" src="https://github.com/user-attachments/assets/104d673a-f5dc-4d23-b6ab-59adbe793e46" />

Added Generics table:

<img width="443" height="169" alt="test case generics table" src="https://github.com/user-attachments/assets/ef489491-fe56-4c3f-8c43-bd5f5a8cfea6" />

Added Tags table

<img width="540" height="323" alt="test case tags table" src="https://github.com/user-attachments/assets/19c3c878-4183-45e4-899b-5f546519de07" />

Test case report

<img width="1301" height="782" alt="test case report" src="https://github.com/user-attachments/assets/fa735bbf-e2ff-4a91-9a69-3d4266b72a4e" />

## YAML Output:

```YAML
#....
TestSuites: 
  - Name: TestSuiteDemo
    TestCases:
      - TestCaseName: "TestDescription_Demo1"
        FunctionalCoverage:  ""
        SimulationTime: "30000000 fs"
        Name: "TestDescription_Demo1"
        Status: PASSED
        Results: {TotalErrors: 0, AlertCount: {Failure: 0, Error: 0, Warning: 0}, PassedCount: 2, AffirmCount: 2, RequirementsPassed: 0, RequirementsGoal: 0, DisabledAlertCount: {Failure: 0, Error: 0, Warning: 0}, ExpectedCount: {Failure: 0, Error: 0, Warning: 0}}
        Title: "Burst test without back-pressure"
        Brief: "This is a short summary of TestDescription_Demo1"
        Description: "This demo shows how to document a test case using a *formatted* description.\nThe goal is to keep it readable in both YAML and HTML.\n\n## What this test does\n- Exercises a simple pass case\n- Demonstrates **bold** and *italic* emphasis\n- Demonstrates bullet lists\n- Demonstrates inline code like `SetTestTag(\"Name\", Value)`\n- Demonstrates links like [OSVVM docs](https://osvvm.github.io)\n- Demonstrates links like [Other link](/home/user/local/path/example)\n\n### Notes\nUse SetTestTag for structured metadata; use Description for narrative context.\nKeep formatting simple and consistent.\n\n#### More heading levels\nThis is a level-4 heading (####).\n#### Escapes for literals\nUse backslash escapes to show markup characters literally:\n- \\* shows a literal asterisk: \\*not italic\\*\n- \\# shows a literal hash: \\#not a heading\n- \\` shows a literal backtick: \\`not code\\`\n"
        Tags:
          Cfg: "CFG_2"
          Scenario: "Maximum Burst"
          Priority: "Medium"
          Condition: "Back-pressure Active"
          datawidth: 8
          burstlength: 256
          syncregs: true
          bufferenable: false
          delay_time: "100 ns"
          cfg_real: 3.14
        TagSummaryVisibility:
          Cfg: false
          Scenario: false
          Priority: false
          Condition: false
          datawidth: false
          burstlength: true
          syncregs: true
          bufferenable: true
          delay_time: true
          cfg_real: true
        TestCaseFileName: "TestDescription_Demo1_G_WIDTH_32_G_PERIOD_10ns_G_CFG1_TRUE_G_CFG2_FALSE"
        Generics:
          G_CFG1: true
          G_CFG2: false
          G_PERIOD: "10ns"
          G_WIDTH: 32
        ElapsedTime: 0.236
      - TestCaseName: "TestDescription_Demo2"
        FunctionalCoverage:  ""
        SimulationTime: "30000000 fs"
        Name: "TestDescription_Demo2"
        Status: PASSED
        Results: {TotalErrors: 0, AlertCount: {Failure: 0, Error: 0, Warning: 0}, PassedCount: 1, AffirmCount: 1, RequirementsPassed: 0, RequirementsGoal: 0, DisabledAlertCount: {Failure: 0, Error: 0, Warning: 0}, ExpectedCount: {Failure: 0, Error: 0, Warning: 0}}
        Title: "Corner Case 7 with Back-pressure"
        Brief: "This is a short summary. Corner Case 7 - Max Burst Length with Back-pressure"
        Description: "This demo2 shows how to document a test case using a *formatted* description.\nThe goal is to keep it readable in both YAML and HTML.\n\n## What this test does\n1. Exercises a simple pass case\n2. Demonstrates **bold** and *italic* emphasis\n3. Demonstrates bullet lists\n4. Demonstrates inline code like `EndOfTestReports`\n5. Demonstrates links like [Report index](../index.html)\n\n### Notes\nUse SetTestTag for structured metadata; use Description for narrative context.\nKeep formatting simple and consistent.\n\n#### More heading levels\nThis section uses #### and can include a link: [OSVVM docs](https://osvvm.github.io).\n#### Escapes\nEscaped literals: \\*not italic\\*, \\#not heading, and \\`not code\\`.\n"
        Tags:
          Configuration: "CFG_1"
          Scenario: "Maximum Burst"
          Priority: "Medium"
          Condition: "Back-pressure Active"
          datawidth: 64
          burstlength: 1024
          syncregs: false
          bufferenable: true
          delay_time: "20000 ns"
          cfg_real: 9.99
        TagSummaryVisibility:
          Configuration: false
          Scenario: false
          Priority: false
          Condition: false
          datawidth: false
          burstlength: true
          syncregs: true
          bufferenable: true
          delay_time: true
          cfg_real: true
        TestCaseFileName: "TestDescription_Demo2_G_WIDTH_8_G_PERIOD_5ns_G_CFG1_FALSE_G_CFG2_TRUE"
        Generics:
          G_CFG1: false
          G_CFG2: true
          G_PERIOD: "5ns"
          G_WIDTH: 8
        ElapsedTime: 0.192
    Title: "Demo Suite name"
    Brief: "Demonstrates suite-level descriptions (in the .pro file) and test-case descriptions/tags (in VHDL)"
    ElapsedTime: 0.602
 #....
```

## Related PR

https://github.com/OSVVM/OSVVM/pull/105

## Related Issues
#67 