### PR TITLE
Replace call to 'which' for Windows (native)

### DIFF
--- a/VendorScripts_GHDL.tcl
+++ b/VendorScripts_GHDL.tcl
@@ -70,7 +70,14 @@ package require fileutil
     # running on MSYS2 - convert which with cygpath
     set ghdl [exec cygpath -m [exec which ghdl]]
   } else {
-    set ghdl [exec which ghdl]
+    set delimiter [expr {[string match "*;*" $::env(PATH)] ? ";" : ":"}]
+    foreach dir [split $::env(PATH) $delimiter] {
+      set fullPath [file join $dir "ghdl.exe"]
+      if {[file exists $fullPath] && [file executable $fullPath]} {
+        set ghdl [file normalize $fullPath]
+				break
+      }
+    }
   }
    
   regexp {GHDL\s+\d+\.\d+\S*} [exec $ghdl --version] VersionString


### PR DESCRIPTION
OSVVM-Script calls `which` also on Windows platforms when it tries to find e.g. the GHDL executable and version. As reported in the past, this doesn't work on Windows e.g. in PowerShell, because Windows does not provide a `which` executable.

This PR implements the functionality of `which` by splitting `$PATH` into multiple directories. Each directory is checked if it contains `ghdl.exe`. If so, the TCL variable `ghdl` is set as before.

It was checked with TCL 9.0.2 and running TCL from PowerShell.